### PR TITLE
Use licensed env to add data only under licensed `cache_paths`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 10.x, 8.x, 12.x ]
+        node: [ 10.x, 12.x ]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 10.x, 8.x, 12.x ]
+        node: [ 10.x, 12.x ]
     steps:
     - uses: actions/checkout@v1
     - uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,14 @@ on: push
 jobs:
   npm_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 10.x, 8.x, 12.x ]
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
 
     - run: npm install
     - uses: jonabc/setup-licensed@v1
@@ -15,8 +21,14 @@ jobs:
 
   licensed_ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 10.x, 8.x, 12.x ]
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node }}
 
     - run: npm install --production
     - uses: jonabc/setup-licensed@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # used for all-branch testing
-.licenses.ignored
+.licenses.ignored/**/*
 
 # Logs
 logs

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "GitHub Actions CI workflow for github/licensed",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint **.js",
-    "test": "eslint **.js && jest"
+    "lint": "eslint **/*.js",
+    "test": "eslint **/*.js && jest"
   },
   "repository": {
     "type": "git",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,14 +60,6 @@ describe('licensed-ci', () => {
     };
   });
 
-  it('raises an error when github_token is not given', async () => {
-    delete options.env.INPUT_GITHUB_TOKEN;
-
-    const exitCode = await exec('node', nodeArgs, options);
-    expect(exitCode).toEqual(core.ExitCode.Failure);
-    expect(outString).toMatch('Input required and not supplied: github_token');
-  });
-
   it('raises an error when commit_message is not given', async () => {
     delete options.env.INPUT_COMMIT_MESSAGE;
 
@@ -146,8 +138,8 @@ describe('licensed-ci', () => {
     it('adds and checks all files in the repository', async () => {
       const exitCode = await exec('node', nodeArgs, options);
       expect(exitCode).toEqual(core.ExitCode.Success);
-      expect(outString).toMatch('git add .');
-      expect(outString).not.toMatch('git diff-index --quiet HEAD --');
+      expect(outString).toMatch('git add -- .');
+      expect(outString).toMatch('git diff-index --quiet HEAD -- .');
     });
   });
 
@@ -162,8 +154,9 @@ describe('licensed-ci', () => {
 
     it('adds and checks licensed cache_paths', async () => {
       const exitCode = await exec('node', nodeArgs, options);
+      console.log(outString);
       expect(exitCode).toEqual(core.ExitCode.Success);
-      expect(outString).toMatch('git add project/licenses test/licenses');
+      expect(outString).toMatch('git add -- project/licenses test/licenses');
       expect(outString).toMatch('git diff-index --quiet HEAD -- project/licenses test/licenses');
     });
   });
@@ -197,6 +190,14 @@ describe('licensed-ci', () => {
         { command: 'git diff-index', exitCode: 1 },
         { command: '', exitCode: 0 }
       ]);
+    });
+
+    it('raises an error when github_token is not given', async () => {
+      delete options.env.INPUT_GITHUB_TOKEN;
+
+      const exitCode = await exec('node', nodeArgs, options);
+      expect(exitCode).toEqual(core.ExitCode.Failure);
+      expect(outString).toMatch('Input required and not supplied: github_token');
     });
 
     it('pushes changes to origin', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -56,7 +56,7 @@ describe('licensed-ci', () => {
       listeners: {
         stdout: data => outString += data.toString()
       },
-      outStream: new stream.Writable({ write: () => { } })
+      outStream: new stream.Writable({ write: () => {} })
     };
   });
 
@@ -154,7 +154,6 @@ describe('licensed-ci', () => {
 
     it('adds and checks licensed cache_paths', async () => {
       const exitCode = await exec('node', nodeArgs, options);
-      console.log(outString);
       expect(exitCode).toEqual(core.ExitCode.Success);
       expect(outString).toMatch('git add -- project/licenses test/licenses');
       expect(outString).toMatch('git diff-index --quiet HEAD -- project/licenses test/licenses');

--- a/test/mocks/@actions/exec.js
+++ b/test/mocks/@actions/exec.js
@@ -15,14 +15,14 @@ sinon.stub(exec, 'exec').callsFake(async (command, args, options) => {
     if (mock.stdout) {
       // echo the mocked stdout using the passed in options
       // map mock.stdout to an array of JSON-escaped content joined by EOL
-      const output = Array.of(mock.stdout).flat().map(arg => JSON.stringify(arg)).join(os.EOL);
+      const output = [mock.stdout].flat().map(arg => JSON.stringify(arg)).join(os.EOL);
       await actionExec(`echo ${output}`, [], options);
     }
 
     if (mock.stderr) {
       // echo the mocked stderr using the passed in options
       // map mock.stderr to an array of JSON-escaped content joined by EOL
-      const output = Array.of(mock.stderr).flat().map(arg => JSON.stringify(arg)).join(os.EOL);
+      const output = [mock.stderr].flat().map(arg => JSON.stringify(arg)).join(os.EOL);
       await actionExec(`echo ${output}`, [], options);
     }
 

--- a/test/mocks/@actions/exec.js
+++ b/test/mocks/@actions/exec.js
@@ -1,4 +1,5 @@
 const exec = require('@actions/exec');
+const os = require('os');
 const sinon = require('sinon');
 
 const actionExec = exec.exec;
@@ -13,12 +14,16 @@ sinon.stub(exec, 'exec').callsFake(async (command, args, options) => {
   if (mock) {
     if (mock.stdout) {
       // echo the mocked stdout using the passed in options
-      await actionExec(`echo ${JSON.stringify(mock.stdout)}`, [], options);
+      // map mock.stdout to an array of JSON-escaped content joined by EOL
+      const output = Array.of(mock.stdout).flat().map(arg => JSON.stringify(arg)).join(os.EOL);
+      await actionExec(`echo ${output}`, [], options);
     }
 
     if (mock.stderr) {
       // echo the mocked stderr using the passed in options
-      await actionExec(`echo ${JSON.stringify(mock.stderr)} >&2`, [], options);
+      // map mock.stderr to an array of JSON-escaped content joined by EOL
+      const output = Array.of(mock.stderr).flat().map(arg => JSON.stringify(arg)).join(os.EOL);
+      await actionExec(`echo ${output}`, [], options);
     }
 
     if (mock.exitCode || mock.exitCode === 0) {

--- a/test/mocks/@actions/exec.js
+++ b/test/mocks/@actions/exec.js
@@ -1,14 +1,31 @@
 const exec = require('@actions/exec');
 const sinon = require('sinon');
 
+const actionExec = exec.exec;
 const execMocks = JSON.parse(process.env.EXEC_MOCKS || '[]');
-sinon.stub(exec, 'exec').callsFake((command, args, options) => {
-  const optionsArray = Object.keys(options || {}).map(key => `${key}:${options[key]}`);
+sinon.stub(exec, 'exec').callsFake(async (command, args, options) => {
+  const optionsArray = Object.keys(options || {}).map(key => `${key}:${JSON.stringify(options[key])}`);
   const fullCommand = [command, ...args, ...optionsArray].join(' ');
   console.log(fullCommand);
 
+  let exitCode = 1;
   const mock = execMocks.find(mock => !!fullCommand.match(mock.command));
-  const exitCode = mock ? mock.exitCode : 0;
+  if (mock) {
+    if (mock.stdout) {
+      // echo the mocked stdout using the passed in options
+      await actionExec(`echo ${JSON.stringify(mock.stdout)}`, [], options);
+    }
+
+    if (mock.stderr) {
+      // echo the mocked stderr using the passed in options
+      await actionExec(`echo ${JSON.stringify(mock.stderr)} >&2`, [], options);
+    }
+
+    if (mock.exitCode || mock.exitCode === 0) {
+      exitCode = mock.exitCode;
+    }
+  }
+
   if (exitCode !== 0 && !options.ignoreReturnCode) {
     return Promise.reject(exitCode);
   }

--- a/test/mocks/@actions/exec.js
+++ b/test/mocks/@actions/exec.js
@@ -29,7 +29,7 @@ sinon.stub(exec, 'exec').callsFake(async (command, args, options) => {
     }
 
     const stderr = getOutputString(mock.stderr);
-    if (mock.stderr) {
+    if (stderr) {
       // echo the mocked stderr using the passed in options
       await actionExec(`echo ${stderr}`, [], options);
     }

--- a/test/mocks/@actions/exec.js
+++ b/test/mocks/@actions/exec.js
@@ -31,7 +31,7 @@ sinon.stub(exec, 'exec').callsFake(async (command, args, options) => {
     const stderr = getOutputString(mock.stderr);
     if (stderr) {
       // echo the mocked stderr using the passed in options
-      await actionExec(`echo ${stderr}`, [], options);
+      await actionExec(`echo ${stderr} >&2`, [], options);
     }
 
     if (mock.exitCode || mock.exitCode === 0) {


### PR DESCRIPTION
This PR updates the action to only `git add` and `git diff-index` github/licensed's configured cache paths.

The `licensed env` command is available in the 2.5.0 release, which provides the data needed.  If the command isn't available then the action will default to the legacy behavior and add + check all files in the repo.

As part of this change I've also added stdout and stderr as supported arguments to the `@actions/exec` mock which will `@actions/exec.exec('echo')` with the provided options so as to preserve any options that capture output from the mocked process.