### PR TITLE
branch workflow operations need to use GitHub token auth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ async function run() {
       throw new Error(`Workflow input value "${workflowInput}" must be one of: ${Object.keys(availableWorkflows).join(', ')}`);
     }
 
-    await utils.configureGitUser();
+    await utils.configureGit();
 
     await workflow.cache();
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,12 +4,14 @@ const fs = require('fs').promises;
 const io = require('@actions/io');
 const stream = require('stream');
 
-async function configureGitUser() {
+async function configureGit() {
   const userName = core.getInput('user_name', { required: true });
   const userEmail = core.getInput('user_email', { required: true });
+  const token = core.getInput('github_token', { required: true });
 
   await exec.exec('git', ['config', 'user.name', userName]);
   await exec.exec('git', ['config', 'user.email', userEmail]);
+  await exec.exec('git', ['remote', 'add', 'licensed-ci-origin', `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
 }
 
 async function getLicensedInput() {
@@ -67,7 +69,7 @@ async function ensureBranch(branch, parent) {
 
   // ensure that branch is up to date with parent
   if (branch !== parent) {
-    await exec.exec('git', ['fetch', 'origin', `${parent}:${parent}`]);
+    await exec.exec('git', ['fetch', 'licensed-ci-origin', `${parent}:${parent}`]);
     exitCode = await exec.exec('git', ['rebase', parent, branch], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${branch} up to date with ${parent}`);
@@ -76,7 +78,7 @@ async function ensureBranch(branch, parent) {
 }
 
 module.exports = {
-  configureGitUser,
+  configureGit,
   getLicensedInput,
   getBranch,
   getCachePaths,

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -76,7 +76,6 @@ async function cache() {
       const token = core.getInput('github_token', { required: true });
       const octokit = new github.GitHub(token);
 
-      await exec.exec('git', ['remote', 'add', 'licensed-ci-origin', `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
       await exec.exec('git', ['commit', '-m', commitMessage]);
       await exec.exec('git', ['push', 'licensed-ci-origin', licensesBranch]);
 

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -47,7 +47,6 @@ async function cache() {
     const token = core.getInput('github_token', { required: true });
     const octokit = new github.GitHub(token);
 
-    await exec.exec('git', ['remote', 'add', 'licensed-ci-origin', `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
     await exec.exec('git', ['commit', '-m', commitMessage]);
     await exec.exec('git', ['push', 'licensed-ci-origin', branch]);
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -4,12 +4,13 @@ const utils = require('../lib/utils');
 
 const mockExec = require('./mocks/@actions/exec');
 
-describe('configureGitUser', () => {
+describe('configureGit', () => {
   let outString;
 
   beforeEach(() => {
     process.env.INPUT_USER_NAME = 'user';
     process.env.INPUT_USER_EMAIL = 'email';
+    process.env.INPUT_GITHUB_TOKEN = 'token';
 
     outString = '';
     mockExec.setLog(log => outString += log + os.EOL);
@@ -23,7 +24,7 @@ describe('configureGitUser', () => {
   it('raises an error when user_name is not given', async () => {
     delete process.env.INPUT_USER_NAME;
 
-    await expect(utils.configureGitUser()).rejects.toThrow(
+    await expect(utils.configureGit()).rejects.toThrow(
       'Input required and not supplied: user_name'
     );
   });
@@ -31,15 +32,30 @@ describe('configureGitUser', () => {
   it('raises an error when user_email is not given', async () => {
     delete process.env.INPUT_USER_EMAIL;
 
-    await expect(utils.configureGitUser()).rejects.toThrow(
+    await expect(utils.configureGit()).rejects.toThrow(
       'Input required and not supplied: user_email'
     );
   });
 
+  it('raises an error when github_token is not given', async () => {
+    delete process.env.INPUT_GITHUB_TOKEN;
+
+    await expect(utils.configureGit()).rejects.toThrow(
+      'Input required and not supplied: github_token'
+    );
+  });
+
   it('configures the repository with the user name and email input', async () => {
-    await utils.configureGitUser();
+    await utils.configureGit();
     expect(outString).toMatch(`git config user.name ${process.env.INPUT_USER_NAME}`);
     expect(outString).toMatch(`git config user.email ${process.env.INPUT_USER_EMAIL}`);
+  });
+
+  it('configures the licensed-ci-origin remote', async () => {
+    await utils.configureGit();
+    expect(outString).toMatch(
+      `git remote add licensed-ci-origin https://x-access-token:${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`
+    );
   });
 });
 

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -122,7 +122,6 @@ describe('cache', () => {
 
     it('pushes changes to origin', async () => {
       await workflow.cache();
-      expect(outString).toMatch(`git remote add licensed-ci-origin https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`);
       expect(outString).toMatch(`git commit -m ${commitMessage}`);
       expect(outString).toMatch(`git push licensed-ci-origin ${branch}`)
     });

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -100,7 +100,6 @@ describe('cache', () => {
 
     it('pushes changes to origin', async () => {
       await workflow.cache();
-      expect(outString).toMatch(`git remote add licensed-ci-origin https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`);
       expect(outString).toMatch(`git commit -m ${commitMessage}`);
       expect(outString).toMatch(`git push licensed-ci-origin ${branch}`)
     });


### PR DESCRIPTION
Hit an error when trying to fetch/rebase using the `branch` workflow on a private repository
```
fatal: could not read Username for 'https://github.com': No such device or address
```

This was handled on pushing changes to GitHub by using authentication via the token provided by the `github_token` action input.  Using the same method here, which requires adding the remote earlier in the process. 