### PR TITLE
Fail action if licensed status doesn't succeed on target branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
     - uses: ./
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        workflow: branch
+        workflow: push

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,13 +30,7 @@ async function run() {
     }
 
     await utils.configureGit();
-
-    // check the status of current cached data
-    const { success } = await workflow.status();
-    if (!success) {
-      console.log('Cached metadata checks failed');
-      await workflow.cache();
-    }
+    await workflow();
   }
   catch (error) {
     core.setFailed(error.message);

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -68,52 +68,8 @@ function getLicensesBranch(branch) {
   return `${branch}-licenses`;
 }
 
-async function cache() {
-  const branch = utils.getBranch();
-  const licensesBranch = getLicensesBranch(branch);
-
-  if (branch === licensesBranch) {
-    // don't need to cache anything on licenses branch, that's already been
-    // done when changes were made on the parent branch
-    return;
-  }
-
-  const { command, configFilePath } = await utils.getLicensedInput();
-
-  // change to a `<branch>/licenses` branch to continue updates
-  await utils.ensureBranch(licensesBranch, branch);
-
-  // cache any metadata updates
-  await exec.exec(command, ['cache', '-c', configFilePath]);
-
-  // stage any changes, checking only configured cache paths if possible
-  const cachePaths = await utils.getCachePaths(command, configFilePath);
-  await exec.exec('git', ['add', '--', ...cachePaths]);
-
-  // check for any changes, checking only configured cache paths if possible
-  const exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });
-  if (exitCode > 0) {
-    // if files were changed, push them back up to origin using the passed in github token
-    const commitMessage = core.getInput('commit_message', { required: true });
-    const token = core.getInput('github_token', { required: true });
-    const octokit = new github.GitHub(token);
-
-    await exec.exec('git', ['commit', '-m', commitMessage]);
-    await exec.exec('git', ['push', 'licensed-ci-origin', licensesBranch]);
-
-    const statusResult = await status();
-    await ensureLicensesPullRequest(octokit, licensesBranch, branch, statusResult);
-  }
-
-  await exec.exec('git', ['checkout', branch]);
-}
-
 async function status() {
   const { command, configFilePath } = await utils.getLicensedInput();
-  const branch = utils.getBranch();
-
-  console.log('');
-  console.log(`Checking status on ${branch}`);
 
   let log = '';
   const options = {
@@ -123,12 +79,54 @@ async function status() {
     }
   };
 
-  console.log(log);
   const exitCode = await exec.exec(command, ['status', '-c', configFilePath], options);
   return { success: exitCode === 0, log };
 }
 
-module.exports = {
-  cache,
-  status,
-};
+async function run() {
+  const branch = utils.getBranch();
+  const licensesBranch = getLicensesBranch(branch);
+
+  // check whether cached metadata needs any updating
+  let statusResult = await status();
+  if (statusResult.success) {
+    return;
+  }
+
+  // recache data only when on a non-licenses branch
+  if (branch !== licensesBranch) {
+    const { command, configFilePath } = await utils.getLicensedInput();
+
+    // change to a `<branch>/licenses` branch to continue updates
+    await utils.ensureBranch(licensesBranch, branch);
+
+    // cache any metadata updates
+    await exec.exec(command, ['cache', '-c', configFilePath]);
+
+    // stage any changes, checking only configured cache paths if possible
+    const cachePaths = await utils.getCachePaths(command, configFilePath);
+    await exec.exec('git', ['add', '--', ...cachePaths]);
+
+    // check for any changes, checking only configured cache paths if possible
+    const exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });
+    if (exitCode > 0) {
+      // if files were changed, push them back up to origin using the passed in github token
+      const commitMessage = core.getInput('commit_message', { required: true });
+      const token = core.getInput('github_token', { required: true });
+      const octokit = new github.GitHub(token);
+
+      await exec.exec('git', ['commit', '-m', commitMessage]);
+      await exec.exec('git', ['push', 'licensed-ci-origin', licensesBranch]);
+
+      statusResult = await status();
+      await ensureLicensesPullRequest(octokit, licensesBranch, branch, statusResult);
+    }
+
+    await exec.exec('git', ['checkout', branch]);
+  }
+
+  // fail if initial check didn't succeed
+  throw new Error('Cached metadata checks failed');
+}
+
+module.exports = run;

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -26,9 +26,29 @@ async function createCommentOnPullRequest(octokit, branch, comment) {
   });
 }
 
-async function cache() {
+async function status() {
+  const { command, configFilePath } = await utils.getLicensedInput();
+
+  let log = '';
+  const options = {
+    ignoreReturnCode: true,
+    listeners: {
+      stdout: data => log += data.toString()
+    }
+  };
+  const exitCode = await exec.exec(command, ['status', '-c', configFilePath], options);
+  return { success: exitCode === 0, log };
+}
+
+async function run() {
   const branch = utils.getBranch();
   const { command, configFilePath } = await utils.getLicensedInput();
+
+  // pre-check, if status succeeds no need to recache
+  let statusResult = await status();
+  if (statusResult.success) {
+    return;
+  }
 
   await utils.ensureBranch(branch, branch);
 
@@ -56,23 +76,12 @@ async function cache() {
       await createCommentOnPullRequest(octokit, branch, prComment);
     }
   }
+
+  // after recaching, check status
+  statusResult = await status();
+  if (!statusResult.success) {
+    throw new Error('Cached metadata checks failed');
+  }
 }
 
-async function status() {
-  const { command, configFilePath } = await utils.getLicensedInput();
-
-  let log = '';
-  const options = {
-    ignoreReturnCode: true,
-    listeners: {
-      stdout: data => log += data.toString()
-    }
-  };
-  const exitCode = await exec.exec(command, ['status', '-c', configFilePath], options);
-  return { success: exitCode === 0, log };
-}
-
-module.exports = {
-  cache,
-  status
-};
+module.exports = run;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -60,7 +60,7 @@ describe('licensed-ci', () => {
   });
 
   it('runs a licensed ci workflow', async () => {
-    options.mocks.exec.unshift({ command: 'licensed status', exitCode: 1 });
+    options.mocks.exec.unshift({ command: 'licensed status', exitCode: 1, count: 1 });
 
     const { out, status } = await run(action, options);
     expect(status).toEqual(core.ExitCode.Success);
@@ -70,12 +70,5 @@ describe('licensed-ci', () => {
     expect(out).toMatch(`${command} cache -c ${configFile}`);
     expect(out).toMatch('git add');
     expect(out).toMatch('git diff-index --quiet HEAD');
-  });
-
-  it('does not cache data if no changes are needed', async () => {
-    const { out, status } = await run(action, options);
-    expect(status).toEqual(core.ExitCode.Success);
-    expect(out).toMatch(`${command} status -c ${configFile}`);
-    expect(out).not.toMatch(`${command} cache -c ${configFile}`);
   });
 });


### PR DESCRIPTION
This fixes an issue with the workflows where they were not failing appropriately based on `licensed status` calls on the target branch.