### PR TITLE
Actions core 1.2.0

### DIFF
--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -57,7 +57,7 @@ async function ensureLicensesPullRequest(octokit, head, base, statusResult) {
     reviewers: [actor]
   })
 
-  console.log(`Created pull request for changes: ${pull.html_url}`);
+  core.info(`Created pull request for changes: ${pull.html_url}`);
 }
 
 function getLicensesBranch(branch) {

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -10,14 +10,14 @@ async function createCommentOnPullRequest(octokit, branch, comment) {
   })
 
   if (data.total_count != 1) {
-    console.log(`Pull request for branch ${branch} not found`);
+    core.info(`Pull request for branch ${branch} not found, skipping comment`);
     return null;
   }
 
   // then add a comment if a pull request exists
   const issue = data.items[0];
-  console.log(`Found pull request ${issue.pull_request.html_url}`);
-  console.log(`Adding comment ${comment}`);
+  core.info(`Found pull request ${issue.pull_request.html_url}`);
+  core.info(`Adding comment ${comment}`);
 
   return octokit.issues.createComment({
     ...github.context.repo,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.1.0.tgz",
-      "integrity": "sha512-KKpo3xzo0Zsikni9tbOsEQkxZBGDsYSJZNkTvmo0gPSXrc98TBOcdTvKwwjitjkjHkreTggWdB1ACiAFVgsuzA=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.0.tgz",
+      "integrity": "sha512-ZKdyhlSlyz38S6YFfPnyNgCDZuAF2T0Qv5eHflNWytPS8Qjvz39bZFMry9Bb/dpSnqWcNeav5yM2CTYpJeY+Dw=="
     },
     "@actions/exec": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/jonabc/licensed-ci#readme",
   "dependencies": {
-    "@actions/core": "^1.1.0",
+    "@actions/core": "^1.2.0",
     "@actions/exec": "^1.0.1",
     "@actions/github": "^1.1.0",
     "@actions/io": "^1.0.1"

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -44,7 +44,6 @@ describe('branch workflow', () => {
     mocks.exec.setLog(log => outString += log + os.EOL);
     mocks.github.setLog(log => outString += log + os.EOL);
 
-    sinon.stub(console, 'log').callsFake(log => outString += log + os.EOL);
     sinon.stub(process.stdout, 'write').callsFake(log => outString += log);
 
     mocks.exec.mock([

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -41,7 +41,6 @@ describe('push workflow', () => {
     mocks.exec.setLog(log => outString += log + os.EOL);
     mocks.github.setLog(log => outString += log + os.EOL);
 
-    sinon.stub(console, 'log').callsFake(log => outString += log + os.EOL);
     sinon.stub(process.stdout, 'write').callsFake(log => outString += log);
 
     mocks.exec.mock([


### PR DESCRIPTION
a little cleanup to get onto core-managed output methods, and avoid stubbing console.log for tests.  stubbing `process.stdout.write` as part of `actions-mocks` might be nice as well, will look into that later