### PR TITLE
Cleanup branch workflow artifacts on success

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Notes:
 - `workflow` - Optional, default: `push`.  Specifies the workflow that is run when metadata updates are found:
   1. `push`
   1. `branch`
+- `cleanup_on_success` - Optional, default: `'false'`.  Only applies to the `branch` workflow.  Set to the string `'true'` to close PRs and delete branches used by the `branch` workflow when `licensed status` succeeds on the parent branch.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: Which workflow to run when metadata is updated.  See README for more details.
     required: false
     default: push
+  cleanup_on_success:
+    description: 'Whether to close open PRs and delete license branches on CI success in user branch. Only used by `branch` workflow'
+      required: false
+      default: 'false'
 outputs:
   licenses_branch:
     description: The branch containing licensed-ci changes.

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,8 @@ inputs:
     default: push
   cleanup_on_success:
     description: 'Whether to close open PRs and delete license branches on CI success in user branch. Only used by `branch` workflow'
-      required: false
-      default: 'false'
+    required: false
+    default: 'false'
 outputs:
   licenses_branch:
     description: The branch containing licensed-ci changes.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 const core = require('@actions/core');
 const exec = require('@actions/exec');
 const fs = require('fs').promises;
+const github = require('@actions/github');
 const io = require('@actions/io');
 const stream = require('stream');
 
@@ -94,6 +95,20 @@ async function findPullRequest(octokit, head, base) {
   return null;
 }
 
+async function closePullRequest(octokit, pullRequest) {
+  if (!pullRequest || pullRequest.state != 'open') {
+    return pullRequest;
+  }
+
+  const { data: pull } = await octokit.pulls.update({
+    ...github.context.repo,
+    pull_number: pullRequest.number,
+    state: 'closed'
+  });
+
+  return pull;
+}
+
 module.exports = {
   configureGit,
   getLicensedInput,
@@ -101,5 +116,6 @@ module.exports = {
   getCachePaths,
   ensureBranch,
   findPullRequest,
+  closePullRequest,
   getOrigin: () => ORIGIN
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -109,6 +109,15 @@ async function closePullRequest(octokit, pullRequest) {
   return pull;
 }
 
+async function deleteBranch(branch) {
+  const remoteRef = `refs/remotes/${ORIGIN}/${branch}`;
+  const exitCode = await exec.exec('git', ['show-ref', '--quiet', '--verify', '--', remoteRef], { ignoreReturnCode: true });
+  if (exitCode == 0) {
+    await exec.exec('git', ['push', ORIGIN, '--delete', branch], { failOnStdErr: true });
+    // console.log(foo);
+  }
+}
+
 module.exports = {
   configureGit,
   getLicensedInput,
@@ -117,5 +126,6 @@ module.exports = {
   ensureBranch,
   findPullRequest,
   closePullRequest,
+  deleteBranch,
   getOrigin: () => ORIGIN
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,8 @@ const fs = require('fs').promises;
 const io = require('@actions/io');
 const stream = require('stream');
 
+const ORIGIN = 'licensed-ci-origin';
+
 async function configureGit() {
   const userName = core.getInput('user_name', { required: true });
   const userEmail = core.getInput('user_email', { required: true });
@@ -11,7 +13,7 @@ async function configureGit() {
 
   await exec.exec('git', ['config', 'user.name', userName]);
   await exec.exec('git', ['config', 'user.email', userEmail]);
-  await exec.exec('git', ['remote', 'add', 'licensed-ci-origin', `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
+  await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
 }
 
 async function getLicensedInput() {
@@ -69,7 +71,7 @@ async function ensureBranch(branch, parent) {
 
   // ensure that branch is up to date with parent
   if (branch !== parent) {
-    await exec.exec('git', ['fetch', 'licensed-ci-origin', `${parent}:${parent}`]);
+    await exec.exec('git', ['fetch', ORIGIN, `${parent}:${parent}`]);
     exitCode = await exec.exec('git', ['rebase', parent, branch], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${branch} up to date with ${parent}`);
@@ -82,5 +84,6 @@ module.exports = {
   getLicensedInput,
   getBranch,
   getCachePaths,
-  ensureBranch
+  ensureBranch,
+  getOrigin: () => ORIGIN
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,11 +110,9 @@ async function closePullRequest(octokit, pullRequest) {
 }
 
 async function deleteBranch(branch) {
-  const remoteRef = `refs/remotes/${ORIGIN}/${branch}`;
-  const exitCode = await exec.exec('git', ['show-ref', '--quiet', '--verify', '--', remoteRef], { ignoreReturnCode: true });
-  if (exitCode == 0) {
-    await exec.exec('git', ['push', ORIGIN, '--delete', branch], { failOnStdErr: true });
-    // console.log(foo);
+  const exitCode = await exec.exec('git', ['ls-remote', '--exit-code', ORIGIN, branch], { ignoreReturnCode: true });
+  if (exitCode === 0) {
+    await exec.exec('git', ['push', ORIGIN, '--delete', branch]);
   }
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -79,11 +79,27 @@ async function ensureBranch(branch, parent) {
   }
 }
 
+async function findPullRequest(octokit, head, base) {
+  let query = `is:pr is:open repo:${process.env.GITHUB_REPOSITORY} head:${head}`;
+  if (base) {
+    query = `${query} base:${base}`
+  }
+
+  const { data } = await octokit.search.issuesAndPullRequests({ q: query });
+  const results = data.items;
+  if (results && results.length > 0) {
+    return results[0];
+  }
+
+  return null;
+}
+
 module.exports = {
   configureGit,
   getLicensedInput,
   getBranch,
   getCachePaths,
   ensureBranch,
+  findPullRequest,
   getOrigin: () => ORIGIN
 };

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -98,7 +98,7 @@ async function run() {
   // check whether cached metadata needs any updating
   let statusResult = await status();
   if (statusResult.success) {
-    if (core.getInput('cleanup_on_success', { required: true }) === 'true') {
+    if (branch !== licensesBranch && core.getInput('cleanup_on_success', { required: true }) === 'true') {
       // delete the licenses branch if it exists
       // the action doesn't deal well with reusing previous branches
       core.info('License checks succeeded. Cleaning up any open branches and PRs');

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -83,22 +83,27 @@ async function status() {
 
 async function run() {
   let licensesUpdated = false;
+  let pullRequestCreated = false;
+
   const branch = utils.getBranch();
   const [licensesBranch, userBranch] = getLicensesBranches(branch);
   core.setOutput('licenses_branch', licensesBranch);
   core.setOutput('user_branch', userBranch);
 
-  // check whether cached metadata needs any updating
-  let statusResult = await status();
-  if (statusResult.success) {
-    return;
-  }
-
-  // find an existing pull request, if one exists
+  // // find an existing pull request, if one exists
   const token = core.getInput('github_token', { required: true });
   const octokit = new github.GitHub(token);
   let pullRequest = await utils.findPullRequest(octokit, licensesBranch, branch);
-  let pullRequestCreated = false;
+
+  // check whether cached metadata needs any updating
+  let statusResult = await status();
+  if (statusResult.success) {
+    // delete the licenses branch if it exists
+    // the action doesn't deal well with reusing previous branches
+    core.info('License checks succeeded. Cleaning up any open branches and PRs');
+    await utils.closePullRequest(octokit, pullRequest);
+    return;
+  }
 
   // recache data only when on a non-licenses branch
   if (branch !== licensesBranch) {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -98,11 +98,14 @@ async function run() {
   // check whether cached metadata needs any updating
   let statusResult = await status();
   if (statusResult.success) {
-    // delete the licenses branch if it exists
-    // the action doesn't deal well with reusing previous branches
-    core.info('License checks succeeded. Cleaning up any open branches and PRs');
-    await utils.closePullRequest(octokit, pullRequest);
-    await utils.deleteBranch(licensesBranch);
+    if (core.getInput('cleanup_on_success', { required: true }) === 'true') {
+      // delete the licenses branch if it exists
+      // the action doesn't deal well with reusing previous branches
+      core.info('License checks succeeded. Cleaning up any open branches and PRs');
+      await utils.closePullRequest(octokit, pullRequest);
+      await utils.deleteBranch(licensesBranch);
+    }
+
     return;
   }
 

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -101,7 +101,7 @@ async function run() {
     if (branch !== licensesBranch && core.getInput('cleanup_on_success', { required: true }) === 'true') {
       // delete the licenses branch if it exists
       // the action doesn't deal well with reusing previous branches
-      core.info('License checks succeeded. Cleaning up any open branches and PRs');
+      core.info('License checks succeeded. Cleaning up branches and PRs');
       await utils.closePullRequest(octokit, pullRequest);
       await utils.deleteBranch(licensesBranch);
     }

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -128,7 +128,7 @@ async function run() {
       // if files were changed, push them back up to origin using the passed in github token
       const commitMessage = core.getInput('commit_message', { required: true });
       await exec.exec('git', ['commit', '-m', commitMessage]);
-      await exec.exec('git', ['push', 'licensed-ci-origin', licensesBranch]);
+      await exec.exec('git', ['push', utils.getOrigin(), licensesBranch]);
       licensesUpdated = true;
 
       if (!pullRequest) {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -102,6 +102,7 @@ async function run() {
     // the action doesn't deal well with reusing previous branches
     core.info('License checks succeeded. Cleaning up any open branches and PRs');
     await utils.closePullRequest(octokit, pullRequest);
+    await utils.deleteBranch(licensesBranch);
     return;
   }
 

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -58,14 +58,6 @@ async function createLicensesPullRequest(octokit, head, base, statusResult) {
   return pull;
 }
 
-async function findLicensesPullRequest(octokit, head, base) {
-  const { data } = await octokit.search.issuesAndPullRequests({
-    q: `is:pr is:open repo:${process.env.GITHUB_REPOSITORY} head:${head} base:${base}`
-  });
-
-  return data.items[0];
-}
-
 function getLicensesBranches(branch) {
   if (branch.endsWith('-licenses')) {
     return [branch, branch.replace('-licenses', '')];
@@ -105,7 +97,7 @@ async function run() {
   // find an existing pull request, if one exists
   const token = core.getInput('github_token', { required: true });
   const octokit = new github.GitHub(token);
-  let pullRequest = await findLicensesPullRequest(octokit, licensesBranch, branch);
+  let pullRequest = await utils.findPullRequest(octokit, licensesBranch, branch);
   let pullRequestCreated = false;
 
   // recache data only when on a non-licenses branch

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -82,7 +82,7 @@ async function run() {
     // if files were changed, push them back up to origin using the passed in github token
     const commitMessage = core.getInput('commit_message', { required: true });
     await exec.exec('git', ['commit', '-m', commitMessage]);
-    await exec.exec('git', ['push', 'licensed-ci-origin', branch]);
+    await exec.exec('git', ['push', utils.getOrigin(), branch]);
     licensesUpdated = true;
 
     // if a PR comment was supplied and PR exists, add comment

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -3,22 +3,6 @@ const exec = require('@actions/exec');
 const github = require('@actions/github');
 const utils = require('../utils');
 
-async function findPullRequest(octokit, branch) {
-  // first try to find a pull request for the branch
-  const { data } = await octokit.search.issuesAndPullRequests({
-    q: `is:pr repo:${process.env.GITHUB_REPOSITORY} head:${branch}`
-  })
-
-  if (data.total_count != 1) {
-    core.info(`Pull request for branch ${branch} not found`);
-    return null;
-  }
-
-  const pull = data.items[0];
-  core.info(`Found pull request ${pull.html_url}`);
-  return pull;
-}
-
 async function commentOnPullRequest(octokit, pullRequest) {
   // if a PR comment was supplied, add it to the pull request
   const comment = core.getInput('pr_comment');
@@ -67,7 +51,7 @@ async function run() {
   // find an open pull request for the changes if one exists
   const token = core.getInput('github_token', { required: true });
   const octokit = new github.GitHub(token);
-  const pullRequest = await findPullRequest(octokit, branch);
+  const pullRequest = await utils.findPullRequest(octokit, branch);
 
   // cache any metadata updates
   await exec.exec(command, ['cache', '-c', configFilePath]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -378,9 +378,9 @@
       }
     },
     "@jonabc/actions-mocks": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@jonabc/actions-mocks/-/actions-mocks-1.1.0.tgz",
-      "integrity": "sha512-wxPHRlnmmKDKDOlT9Ayr+Pnmli8V98eVWuyEvwjG0+ULY0Oxq2JkXUGZDU1Buu1OF6vDr82DFMfVne13twnT6g==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@jonabc/actions-mocks/-/actions-mocks-1.1.1.tgz",
+      "integrity": "sha512-WfKK5YhsotmLpqoZv9iAyETI6/I6u0m0WHH0sQoueL03GTC/6Te/5A8+ta3TK+8JsPos/ze9NFN683GTzmtPgQ==",
       "dev": true,
       "requires": {
         "@actions/exec": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@actions/io": "^1.0.1"
   },
   "devDependencies": {
-    "@jonabc/actions-mocks": "^1.1.0",
+    "@jonabc/actions-mocks": "^1.1.1",
     "acorn": "^6.3.0",
     "eslint": "^6.3.0",
     "jest": "^24.9.0",

--- a/test/fixtures/testSearchResult.json
+++ b/test/fixtures/testSearchResult.json
@@ -11,9 +11,10 @@
       "html_url": "https://github.com/jonabc/setup-licensed/pull/1",
       "number": 1,
       "comments": 0,
+      "state": "open",
       "created_at": "2019-09-14T02:28:45Z",
       "updated_at": "2019-09-14T02:28:54Z",
-      "closed_at": "2019-09-14T02:28:51Z",
+      "closed_at": null,
       "pull_request": {
         "url": "https://api.github.com/repos/jonabc/setup-licensed/pulls/1",
         "html_url": "https://github.com/jonabc/setup-licensed/pull/1",

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -53,7 +53,7 @@ describe('configureGit', () => {
   it('configures the licensed-ci-origin remote', async () => {
     await utils.configureGit();
     expect(outString).toMatch(
-      `git remote add licensed-ci-origin https://x-access-token:${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`
+      `git remote add ${utils.getOrigin()} https://x-access-token:${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`
     );
   });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -361,21 +361,21 @@ describe('deleteBranch', () => {
 
   it('deletes a git branch', async () => {
     await utils.deleteBranch(branch);
-    expect(outString).toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 
   it('does not try to delete a branch that doesn\'t exist', async () => {
-    mocks.exec.mock({ command: 'git show-ref', exitCode: 2 });
+    mocks.exec.mock({ command: 'git ls-remote', exitCode: 2 });
     await utils.deleteBranch(branch);
-    expect(outString).toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).not.toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 
   it('raises an error if branch delete fails', async () => {
     mocks.exec.mock({ command: 'git push', exitCode: 2 });
     await expect(utils.deleteBranch(branch)).rejects.toThrow();
-    expect(outString).toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 });

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -115,10 +115,17 @@ describe('branch workflow', () => {
   it('cleans pull requests if status checks succeed', async () => {
     mocks.exec.mock([
       { command: 'licensed status', exitCode: 0 },
+      { command: 'git show-ref', exitCode: 0 },
+      { command: 'git push', exitCode: 0 }
+    ]);
+
     await workflow();
 
     expect(utils.closePullRequest.callCount).toEqual(1);
     expect(outString).toMatch(`PATCH ${updatePullsUrl} : ${JSON.stringify({ state: 'closed' })}`);
+    expect(utils.deleteBranch.callCount).toEqual(1);
+    expect(outString).toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 
   describe('with no cached file changes', () => {

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -153,7 +153,7 @@ describe('branch workflow', () => {
       ]);
 
       await expect(workflow()).rejects.toThrow();
-      const query = `is:pr is:open repo:${process.env.GITHUB_REPOSITORY} head:${branch} base:${parent}`
+      const query = `is:pr is:open repo:${process.env.GITHUB_REPOSITORY} head:${branch} base:${parent}`;
       expect(outString).toMatch(`GET ${issuesSearchUrl}?q=${encodeURIComponent(query)}`);
 
       let match = outString.match(`POST ${createPRUrl} : (.+)`);

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -117,7 +117,7 @@ describe('branch workflow', () => {
     process.env.INPUT_CLEANUP_ON_SUCCESS = 'true';
     mocks.exec.mock([
       { command: 'licensed status', exitCode: 0 },
-      { command: 'git show-ref', exitCode: 0 },
+      { command: 'git ls-remote', exitCode: 0 },
       { command: 'git push', exitCode: 0 }
     ]);
 
@@ -126,7 +126,7 @@ describe('branch workflow', () => {
     expect(utils.closePullRequest.callCount).toEqual(1);
     expect(outString).toMatch(`PATCH ${updatePullsUrl} : ${JSON.stringify({ state: 'closed' })}`);
     expect(utils.deleteBranch.callCount).toEqual(1);
-    expect(outString).toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 
@@ -138,7 +138,7 @@ describe('branch workflow', () => {
     expect(utils.closePullRequest.callCount).toEqual(0);
     expect(outString).not.toMatch(`PATCH ${updatePullsUrl} : ${JSON.stringify({ state: 'closed' })}`);
     expect(utils.deleteBranch.callCount).toEqual(0);
-    expect(outString).not.toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).not.toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).not.toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 
@@ -152,7 +152,7 @@ describe('branch workflow', () => {
     expect(utils.closePullRequest.callCount).toEqual(0);
     expect(outString).not.toMatch(`PATCH ${updatePullsUrl} : ${JSON.stringify({ state: 'closed' })}`);
     expect(utils.deleteBranch.callCount).toEqual(0);
-    expect(outString).not.toMatch(`git show-ref --quiet --verify -- refs/remotes/${utils.getOrigin()}/${branch}`);
+    expect(outString).not.toMatch(`git ls-remote --exit-code ${utils.getOrigin()} ${branch}`);
     expect(outString).not.toMatch(`git push ${utils.getOrigin()} --delete ${branch}`);
   });
 

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -109,7 +109,7 @@ describe('branch workflow', () => {
   describe('with no cached file changes', () => {
     it('does not push changes to origin', async () => {
       await expect(workflow()).rejects.toThrow();
-      expect(outString).not.toMatch(`git push licensed-ci-origin ${branch}`);
+      expect(outString).not.toMatch(`git push ${utils.getOrigin()} ${branch}`);
       expect(outString).toMatch(new RegExp(`set-output.*licenses_updated.*false`));
     });
   });
@@ -135,7 +135,7 @@ describe('branch workflow', () => {
     it('pushes changes to origin', async () => {
       await expect(workflow()).rejects.toThrow();
       expect(outString).toMatch(`git commit -m ${commitMessage}`);
-      expect(outString).toMatch(`git push licensed-ci-origin ${branch}`);
+      expect(outString).toMatch(`git push ${utils.getOrigin()} ${branch}`);
       expect(outString).toMatch(new RegExp(`set-output.*licenses_updated.*true`));
     });
 

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -141,7 +141,7 @@ describe('push workflow', () => {
       );
 
       await workflow();
-      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
+      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20is%3Aopen%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
       expect(outString).not.toMatch(`POST ${createCommentUrl}`);
     });
 
@@ -154,7 +154,7 @@ describe('push workflow', () => {
       );
 
       await workflow();
-      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
+      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20is%3Aopen%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
       expect(outString).not.toMatch(`POST ${createCommentUrl}`);
     });
 
@@ -164,7 +164,7 @@ describe('push workflow', () => {
       mocks.github.mock({ method: 'POST', uri: createCommentUrl });
 
       await workflow();
-      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
+      expect(outString).toMatch(`GET ${issuesSearchUrl}?q=is%3Apr%20is%3Aopen%20repo%3A${owner}%2F${repo}%20head%3A${branch}`);
       expect(outString).toMatch(`POST ${createCommentUrl} : ${JSON.stringify({ body: process.env.INPUT_PR_COMMENT})}`);
     });
 

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -20,12 +20,13 @@ describe('push workflow', () => {
 
   // to match the response from the testSearchResult.json fixture
   const owner = 'jonabc';
-  const repo = 'repo';
+  const repo = 'setup-licensed';
 
   const issuesSearchEndpoint = octokit.search.issuesAndPullRequests.endpoint();
   const issuesSearchUrl = issuesSearchEndpoint.url.replace('https://api.github.com', '');
   const searchResultFixture = require(path.join(__dirname, '..', 'fixtures', 'testSearchResult'));
 
+  const processEnv = process.env;
   let outString;
 
   beforeEach(() => {
@@ -63,6 +64,7 @@ describe('push workflow', () => {
   afterEach(() => {
     sinon.restore();
     mocks.exec.restore();
+    process.env = processEnv;
   });
 
   it('does not cache data if no changes are needed', async () => {

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -101,7 +101,7 @@ describe('push workflow', () => {
   describe('with no cached file changes', () => {
     it('does not push changes to origin', async () => {
       await workflow();
-      expect(outString).not.toMatch(`git push licensed-ci-origin ${branch}`);
+      expect(outString).not.toMatch(`git push ${utils.getOrigin()} ${branch}`);
       expect(outString).toMatch(new RegExp(`set-output.*licenses_updated.*false`));
     });
   });
@@ -130,7 +130,7 @@ describe('push workflow', () => {
 
       await workflow();
       expect(outString).toMatch(`git commit -m ${commitMessage}`);
-      expect(outString).toMatch(`git push licensed-ci-origin ${branch}`);
+      expect(outString).toMatch(`git push ${utils.getOrigin()} ${branch}`);
       expect(outString).toMatch(new RegExp(`set-output.*licenses_updated.*true`));
     });
 


### PR DESCRIPTION
This PR adds in the option to cleanup branch workflow artifacts if they exist when `licensed status` succeeds on the users branch.  The extra action is gated by a new `cleanup_on_success` input flag.

1. close any open PR for the licenses branch, in the event that licenses were updated on the user branch directly
2. delete the created licenses branch if it exists

Tested this with a fake release branch on this repo, which showed that my original strategy to use `git show-ref` wouldn't work because the separate git origin used in this action, `licensed-ci-origin` hasn't been fetched when this code is run.  Updated to use `git ls-remote` and all is working 👍 

```
License checks succeeded. Cleaning up any open branches and PRs
git ls-remote --exit-code licensed-ci-origin releases/test-cleanup-on-success-licenses
ffe9c357e2245caf287844207250c7a170d5bd80	refs/heads/releases/test-cleanup-on-success-licenses
git push licensed-ci-origin --delete releases/test-cleanup-on-success-licenses
To https://github.com/jonabc/licensed-ci.git
 - [deleted]         releases/test-cleanup-on-success-licenses
```