### PR TITLE
Merge user branch into licenses branch in branch strategy workflow

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -69,15 +69,6 @@ async function ensureBranch(branch, parent) {
   if (exitCode != 0) {
     throw new Error(`Unable to find or create the ${branch} branch`);
   }
-
-  // ensure that branch is up to date with parent
-  if (branch !== parent) {
-    await exec.exec('git', ['fetch', ORIGIN, `${parent}:${parent}`]);
-    exitCode = await exec.exec('git', ['rebase', parent, branch], { ignoreReturnCode: true });
-    if (exitCode !== 0) {
-      throw new Error(`Unable to get ${branch} up to date with ${parent}`);
-    }
-  }
 }
 
 async function findPullRequest(octokit, head, base) {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -113,8 +113,14 @@ async function run() {
   if (branch !== licensesBranch) {
     const { command, configFilePath } = await utils.getLicensedInput();
 
-    // change to a `<branch>/licenses` branch to continue updates
+    // change to a `<branch>-licenses` branch to continue updates
     await utils.ensureBranch(licensesBranch, branch);
+
+    // ensure that branch is up to date with parent
+    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `origin/${branch}`], { ignoreReturnCode: true });
+    if (exitCode !== 0) {
+      throw new Error(`Unable to get ${licensesBranch} up to date with ${branch}`);
+    }
 
     // cache any metadata updates
     await exec.exec(command, ['cache', '-c', configFilePath]);
@@ -124,7 +130,7 @@ async function run() {
     await exec.exec('git', ['add', '--', ...cachePaths]);
 
     // check for any changes, checking only configured cache paths if possible
-    const exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });
+    exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });
     if (exitCode > 0) {
       // if files were changed, push them back up to origin using the passed in github token
       const commitMessage = core.getInput('commit_message', { required: true });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -216,19 +216,6 @@ describe('ensureBranch', () => {
         `Unable to find or create the ${branch} branch`
       );
     });
-
-    it('rebases branch on parent', async () => {
-      await utils.ensureBranch(branch, parent);
-      expect(outString).toMatch(`git rebase ${parent} ${branch}`);
-    });
-
-    it('raises an error if rebasing failed', async () => {
-      mocks.exec.mock({ command: `git rebase ${parent} ${branch}`, exitCode: 1 });
-
-      await expect(utils.ensureBranch(branch, parent)).rejects.toThrow(
-        `Unable to get ${branch} up to date with ${parent}`
-      );
-    });
   });
 
   describe('when branch === parent', () => {
@@ -245,11 +232,6 @@ describe('ensureBranch', () => {
       await expect(utils.ensureBranch(branch, branch)).rejects.toThrow(
         `Unable to find or create the ${branch} branch`
       );
-    });
-
-    it('does not perform a rebase', async () => {
-      await utils.ensureBranch(branch, branch);
-      expect(outString).not.toMatch(`git rebase ${branch} ${branch}`);
     });
   });
 });

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -88,6 +88,7 @@ describe('branch workflow', () => {
     expect(utils.getBranch.callCount).toEqual(1);
     expect(utils.getLicensedInput.callCount).toBeGreaterThan(1);
     expect(utils.ensureBranch.withArgs(branch, parent).callCount).toEqual(1);
+    expect(outString).toMatch(`git merge -s recursive -Xtheirs origin/${parent}`);
     expect(outString).toMatch(`${command} cache -c ${configFile}`);
     expect(utils.getCachePaths.callCount).toEqual(1);
     expect(outString).toMatch(`${command} env`);


### PR DESCRIPTION
This PR changes the method of updating the licenses branch in the `branch` workflow from rebasing to merging.

Rebasing could require use of `--force` or other workarounds when getting the licenses branch updated from the user's work branch.
Users might have rules in place on a repo that prohibit force pushes.  merging up is safer and easier to reason about, and gives users the option on how to merge the changes into the work branch - merge, squash, rebase