### PR TITLE
Set a default for github_token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,8 @@ inputs:
     default: 'licensed'
   github_token:
     description: 'Access token to push license updates to GitHub'
-    required: true
+    required: false
+    default: ${{ github.token }}
   config_file:
     description: 'Path to licensed configuration file'
     required: false


### PR DESCRIPTION
If you set a value to false and provide a default, it will get autopopulated for you. In this case setting this `${{ github.token }}` means that users of your action don't need to set this value at all and it's one line easier to set up 😄