### PR TITLE
Handle running licensed-ci from pull request events

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,16 +27,18 @@ async function getLicensedInput() {
   return { command, configFilePath };
 }
 
-function getBranch() {
-  // checkout the target branch
-  let branch = process.env.GITHUB_REF;
-  if (!branch) {
-    throw new Error('Current ref not available');
-  } else if (!branch.startsWith('refs/heads')) {
-    throw new Error(`${branch} does not reference a branch`);
+function getBranch(context) {
+  if (context.payload && context.payload.ref) {
+    const ref = context.payload.ref;
+    if (!ref.startsWith('refs/heads')) {
+      throw new Error(`${ref} does not reference a branch`);
+    }
+    return ref.replace('refs/heads/', '');
+  } else if (context.payload && context.payload.pull_request) {
+    return context.payload.pull_request.head.ref;
   }
 
-  return branch.replace('refs/heads/', '');
+  throw new Error(`Unable to determine a HEAD branch reference for ${context.eventName} event type`);
 }
 
 async function getCachePaths(command, configFilePath) {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -120,7 +120,7 @@ async function notifyUser(octokit, userPullRequest, licensesPullRequest, created
 
 function getLicensesBranches(branch) {
   if (branch.endsWith('-licenses')) {
-    return [branch, branch.replace('-licenses', '')];
+    return [branch, branch.replace(/-licenses$/, '')];
   }
 
   return [`${branch}-licenses`, branch];

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -153,7 +153,7 @@ async function run() {
   // // find an existing pull request, if one exists
   const token = core.getInput('github_token', { required: true });
   const octokit = new github.GitHub(token);
-  let licensesPullRequest = await utils.findPullRequest(octokit, { head: licensesBranch, base: branch });
+  let licensesPullRequest = await utils.findPullRequest(octokit, { head: licensesBranch, base: userBranch });
 
   // check whether cached metadata needs any updating
   let statusResult = await status();
@@ -174,12 +174,12 @@ async function run() {
     const { command, configFilePath } = await utils.getLicensedInput();
 
     // change to a `<branch>-licenses` branch to continue updates
-    await utils.ensureBranch(licensesBranch, branch);
+    await utils.ensureBranch(licensesBranch, userBranch);
 
     // ensure that branch is up to date with parent
-    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `origin/${branch}`], { ignoreReturnCode: true });
+    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `origin/${userBranch}`], { ignoreReturnCode: true });
     if (exitCode !== 0) {
-      throw new Error(`Unable to get ${licensesBranch} up to date with ${branch}`);
+      throw new Error(`Unable to get ${licensesBranch} up to date with ${userBranch}`);
     }
 
     // cache any metadata updates
@@ -198,14 +198,14 @@ async function run() {
       await exec.exec('git', ['push', utils.getOrigin(), licensesBranch]);
       licensesUpdated = true;
 
-      const userPullRequest = await utils.findPullRequest(octokit, { head: branch, "-base": branch });
+      const userPullRequest = await utils.findPullRequest(octokit, { head: userBranch, "-base": userBranch });
       if (!licensesPullRequest) {
-        licensesPullRequest = await createLicensesPullRequest(octokit, licensesBranch, branch, userPullRequest);
+        licensesPullRequest = await createLicensesPullRequest(octokit, licensesBranch, userBranch, userPullRequest);
         pullRequestCreated = true;
       }
 
       statusResult = await status();
-      await notifyStatus(octokit, branch, userPullRequest, licensesPullRequest, statusResult);
+      await notifyStatus(octokit, userBranch, userPullRequest, licensesPullRequest, statusResult);
 
       if (userPullRequest) {
         await notifyUser(octokit, userPullRequest, licensesPullRequest, pullRequestCreated);

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -145,7 +145,7 @@ async function run() {
   let licensesUpdated = false;
   let pullRequestCreated = false;
 
-  const branch = utils.getBranch();
+  const branch = utils.getBranch(github.context);
   const [licensesBranch, userBranch] = getLicensesBranches(branch);
   core.setOutput('licenses_branch', licensesBranch);
   core.setOutput('user_branch', userBranch);

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -34,7 +34,7 @@ async function status() {
 
 async function run() {
   let licensesUpdated = false;
-  const branch = utils.getBranch();
+  const branch = utils.getBranch(github.context);
   core.setOutput('licenses_branch', branch);
   core.setOutput('user_branch', branch);
 

--- a/test/fixtures/push_payload.json
+++ b/test/fixtures/push_payload.json
@@ -1,0 +1,3 @@
+{
+  "ref": "refs/heads/branch"
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -31,8 +31,8 @@ describe('licensed-ci', () => {
         INPUT_COMMAND: command,
         INPUT_CONFIG_FILE: configFile,
         INPUT_WORKFLOW: 'push',
-        GITHUB_REF: `refs/heads/${branch}`,
-        GITHUB_REPOSITORY: `${owner}/${repo}`
+        GITHUB_REPOSITORY: `${owner}/${repo}`,
+        GITHUB_EVENT_PATH: path.resolve(__dirname, './fixtures/push_payload.json')
       },
       mocks: {
         exec: [

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -110,34 +110,35 @@ describe('getLicensedInput', () => {
 });
 
 describe('getBranch', () => {
-  beforeEach(() => {
-    process.env.GITHUB_REF = 'refs/heads/branch';
-  });
-
   it('raises an error when ref is not found', () => {
-    delete process.env.GITHUB_REF;
-
-    expect(() => utils.getBranch()).toThrow(
-      'Current ref not available'
+    expect(() => utils.getBranch({})).toThrow(
+      'Unable to determine a HEAD branch reference for undefined event type'
     );
   });
 
   it('raises an error when ref is not a branch', () => {
-    process.env.GITHUB_REF = 'refs/tags/v1';
-
-    expect(() => utils.getBranch()).toThrow(
+    const context = { payload: { ref: 'refs/tags/v1' }};
+    expect(() => utils.getBranch(context)).toThrow(
       'refs/tags/v1 does not reference a branch'
     );
   });
 
-  it('returns the branch name', () => {
-    expect(utils.getBranch()).toEqual('branch');
+  it('returns the branch name from payload.ref', () => {
+    const context = { payload: { ref: 'refs/heads/branch' }};
+
+    expect(utils.getBranch(context)).toEqual('branch');
+  });
+
+  it('returns the branch name from a pull request payload', () => {
+    const context = { payload: { pull_request: { head: { ref: 'branch' }}}};
+
+    expect(utils.getBranch(context)).toEqual('branch');
   });
 });
 
 describe('getCachePaths', () => {
   const command = 'licensed';
-  const configFile = path.normalize(path.join(__dirname, '..', '.licensed.yml'));
+  const configFile = path.resolve(__dirname, '..', '.licensed.yml');
   let outString;
 
   beforeEach(() => {

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -29,6 +29,8 @@ describe('push workflow', () => {
   const processEnv = process.env;
   let outString;
 
+  const contextPayload = github.context.payload;
+
   beforeEach(() => {
     process.env = {
       ...process.env,
@@ -38,7 +40,6 @@ describe('push workflow', () => {
       INPUT_USER_EMAIL: userEmail,
       INPUT_COMMAND: command,
       INPUT_CONFIG_FILE: configFile,
-      GITHUB_REF: `refs/heads/${branch}`,
       GITHUB_REPOSITORY: `${owner}/${repo}`,
     };
 
@@ -47,6 +48,8 @@ describe('push workflow', () => {
     mocks.github.setLog(log => outString += log + os.EOL);
 
     sinon.stub(process.stdout, 'write').callsFake(log => outString += log);
+
+    github.context.payload = { ref: `refs/heads/${branch}` };
 
     mocks.exec.mock([
       { command: 'licensed env', exitCode: 1 },
@@ -65,6 +68,7 @@ describe('push workflow', () => {
     sinon.restore();
     mocks.exec.restore();
     process.env = processEnv;
+    github.context.payload = contextPayload;
   });
 
   it('does not cache data if no changes are needed', async () => {


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/44

Updates `utils.getBranch` to pull branch ref information from `github.context.payload` rather than `$GITHUB_REF`.  On pull request events, `GITHUB_REF` looks like `refs/pull/X/merge` which could be parsed for a pull request number.  If I did that though, I would then need to query the API to get the same pull request information that exists in github.context.payload 🤷 