### PR TITLE
Fix checks to get the branch to test from a PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,14 @@ Notes:
 
 Basic usage with a licensed release package using [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed)
 ```yaml
+# also works with pull_request event
+on: push
+
 steps:
-- uses: actions/checkout@master
+# if using actions/checkout at major version 2 or greater,
+# please set fetch-depth to a high number, or to 0.
+# running this action can require access to more than just the latest commit on a branch
+- uses: actions/checkout@v1
 - uses: jonabc/setup-licensed@v1
   with:
     version: 2.x
@@ -78,10 +84,16 @@ steps:
       })
 ```
 
-Basic usage with bundled licensed gem
+Basic usage installing licensed gem using bundler + Gemfile
 ```yaml
+# also works with pull_request event
+on: push
+
 steps:
-- uses: actions/checkout@master
+# if using actions/checkout at major version 2 or greater,
+# please set fetch-depth to a high number, or to 0.
+# running this action can require access to more than just the latest commit on a branch
+- uses: actions/checkout@v1
 - uses: actions/setup-ruby@v1
   with:
     ruby-version: 2.6.x
@@ -91,6 +103,10 @@ steps:
     github_token: ${{ secrets.GITHUB_TOKEN }}
     command: 'bundle exec licensed' # or bin/licensed when using binstubs
 ```
+
+#### Supported Events
+
+This action supports the `push` and `pull_request` events.
 
 # License
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,14 +28,14 @@ async function getLicensedInput() {
 }
 
 function getBranch(context) {
-  if (context.payload && context.payload.ref) {
+  if (context.payload && context.payload.pull_request) {
+    return context.payload.pull_request.head.ref;
+  } else if (context.payload && context.payload.ref) {
     const ref = context.payload.ref;
     if (!ref.startsWith('refs/heads')) {
       throw new Error(`${ref} does not reference a branch`);
     }
     return ref.replace('refs/heads/', '');
-  } else if (context.payload && context.payload.pull_request) {
-    return context.payload.pull_request.head.ref;
   }
 
   throw new Error(`Unable to determine a HEAD branch reference for ${context.eventName} event type`);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -130,7 +130,7 @@ describe('getBranch', () => {
   });
 
   it('returns the branch name from a pull request payload', () => {
-    const context = { payload: { pull_request: { head: { ref: 'branch' }}}};
+    const context = { payload: { ref: 'refs/pulls/123/merge', pull_request: { head: { ref: 'branch' }}}};
 
     expect(utils.getBranch(context)).toEqual('branch');
   });


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/47

This is a small fix that reverses the order of checks when finding the branch relating to an incoming event.  It looks like PR events still have a ref property in the payload though that's not being documented anyplace I've looked 🤷 😞 

I've also used this opportunity to add a bit of extra information to the readme

cc @johlju