### PR TITLE
Give better error message for tags

### DIFF
--- a/.github/workflows/release-licenses.yml
+++ b/.github/workflows/release-licenses.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - 'releases/*'
+    tags-ignore:
+      - '**'
 
 jobs:
   test:

--- a/.github/workflows/test-licenses.yml
+++ b/.github/workflows/test-licenses.yml
@@ -1,8 +1,13 @@
-name: "Test"
-on: push
+name: "Run licensed in test"
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 jobs:
-  npm_test:
+  licensed_ci:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -13,8 +18,11 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - run: npm install
+    - run: npm install --production
     - uses: jonabc/setup-licensed@v1
       with:
         version: '2.x'
-    - run: npm run test
+    - uses: ./
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        workflow: push

--- a/README.md
+++ b/README.md
@@ -57,7 +57,12 @@ Notes:
 Basic usage with a licensed release package using [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed)
 ```yaml
 # also works with pull_request event
-on: push
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 steps:
 # if using actions/checkout at major version 2 or greater,
@@ -87,7 +92,12 @@ steps:
 Basic usage installing licensed gem using bundler + Gemfile
 ```yaml
 # also works with pull_request event
-on: push
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 steps:
 # if using actions/checkout at major version 2 or greater,
@@ -106,7 +116,7 @@ steps:
 
 #### Supported Events
 
-This action supports the `push` and `pull_request` events.
+This action supports the `push` and `pull_request` events.  When using `push`, the action workflow should include `tags-ignore: '**'` to avoid running the action on pushed tags.  New tags point to code but do not represent new or changed code that could include updated dependencies.
 
 # License
 


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/52

Actions still doesn't support neutral exit codes as far as I can tell, so in the meantime I've updated the code to give a better error message when using licensed-ci on a tag ref.  I've also updated the README and usage in this repo to include `tags-ignore: '**'` and give guidance against using licensed on pushed tags