### PR TITLE
don't include cache paths that don't exist on disk

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 const core = require('@actions/core');
 const exec = require('@actions/exec');
-const fs = require('fs').promises;
+const fs = require('fs');
 const github = require('@actions/github');
 const io = require('@actions/io');
 const stream = require('stream');
@@ -22,7 +22,7 @@ async function getLicensedInput() {
   await io.which(command.split(' ')[0], true); // check that command is runnable
 
   const configFilePath = core.getInput('config_file', { required: true });
-  await fs.access(configFilePath); // check that config file exists
+  await fs.promises.access(configFilePath); // check that config file exists
 
   return { command, configFilePath };
 }
@@ -70,6 +70,16 @@ async function getCachePaths(command, configFilePath) {
 
   // if `licensed env` failed or there was no output, add updated files for the whole repo
   return ['.'];
+}
+
+async function filterCachePaths(paths) {
+  const filteredPaths = await Promise.all(paths.map(path => 
+    // exclude paths that don't exist
+    fs.promises.access(path, fs.constants.R_OK)
+               .then(() => path)
+               .catch(() => null)
+  ));
+  return filteredPaths.filter(p=>p);
 }
 
 async function ensureBranch(branch, parent) {
@@ -126,6 +136,7 @@ module.exports = {
   getLicensedInput,
   getBranch,
   getCachePaths,
+  filterCachePaths,
   ensureBranch,
   findPullRequest,
   closePullRequest,

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -172,7 +172,7 @@ async function run() {
 
     // stage any changes, checking only configured cache paths if possible
     const cachePaths = await utils.getCachePaths(command, configFilePath);
-    await exec.exec('git', ['add', '--', ...cachePaths]);
+    await exec.exec('git', ['add', '--', ...(await utils.filterCachePaths(cachePaths))]);
 
     // check for any changes, checking only configured cache paths if possible
     exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -44,7 +44,7 @@ async function run() {
 
   // stage any changes, checking only configured cache paths if possible
   const cachePaths = await utils.getCachePaths(command, configFilePath);
-  await exec.exec('git', ['add', '--', ...cachePaths]);
+  await exec.exec('git', ['add', '--', ...(await utils.filterCachePaths(cachePaths))]);
 
   // check for any changes, checking only configured cache paths if possible
   const exitCode = await exec.exec('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths], { ignoreReturnCode: true });

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -58,6 +58,7 @@ describe('branch workflow', () => {
     sinon.stub(utils, 'ensureBranch').resolves();
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
+    sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .resolves(1)
@@ -111,6 +112,9 @@ describe('branch workflow', () => {
 
     expect(utils.getCachePaths.callCount).toEqual(1);
     expect(utils.getCachePaths.getCall(0).args).toEqual([command, configFilePath]);
+
+    expect(utils.filterCachePaths.callCount).toEqual(1);
+    expect(utils.filterCachePaths.getCall(0).args).toEqual([cachePaths]);
 
     expect(exec.exec.getCall(2).args).toEqual(['git', ['add', '--', ...cachePaths]]);
     expect(exec.exec.getCall(3).args).toEqual([

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -47,6 +47,7 @@ describe('push workflow', () => {
     sinon.stub(utils, 'ensureBranch').resolves();
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
+    sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .rejects()
@@ -102,6 +103,9 @@ describe('push workflow', () => {
 
     expect(utils.getCachePaths.callCount).toEqual(1);
     expect(utils.getCachePaths.getCall(0).args).toEqual([command, configFilePath]);
+
+    expect(utils.filterCachePaths.callCount).toEqual(1);
+    expect(utils.filterCachePaths.getCall(0).args).toEqual([cachePaths]);
 
     expect(exec.exec.getCall(1).args).toEqual(['git', ['add', '--', ...cachePaths]]);
     expect(exec.exec.getCall(2).args).toEqual(


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/46

This PR attempts to address the above issue by filtering out licensed's cache paths that don't exist on disk.  The scenario mentioned in the issue is that a command entrypoint doesn't have any external dependencies, and so licensed never creates a directory on disk to hold dependency metadata.

This is a low-touch fix to check that each cache path directory exists on disk before using it as an argument to git add.

/cc @mhagger @gudmunder FYI finally getting around to addressing this, sorry for the delay