### PR TITLE
run tests in CI on pull request triggers

### DIFF
--- a/.github/workflows/test-licenses.yml
+++ b/.github/workflows/test-licenses.yml
@@ -2,9 +2,10 @@ name: "Run licensed in test"
 on:
   push:
     branches:
-      - '**'
+      - 'master'
     tags-ignore:
       - '**'
+  pull_request:
 
 jobs:
   licensed_ci:

--- a/.github/workflows/test-licenses.yml
+++ b/.github/workflows/test-licenses.yml
@@ -15,6 +15,8 @@ jobs:
         node: [ 10.x, 12.x, 14.x, 16.x ]
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
     - uses: actions/setup-node@v2
       with:
         cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: "Test"
-on: push
+on: pull_request
 
 jobs:
   npm_test:


### PR DESCRIPTION
update the trigger for running test actions to be on any pull request activities rather than PRs, to account for PRs opened from forks