### PR TITLE
Clear auth-based extra headers when pushing licensing changes and make action more reliable

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,6 +17,33 @@ async function configureGit() {
   await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
 }
 
+async function extraHeaderConfigWithoutAuthorization() {
+  const serverUrl = new URL(process.env['GITHUB_SERVER_URL'] || 'https://github.com');
+  const configValues = [];
+
+  // check for both broad and specific extraheader values
+  for (const key of ['http.extraheader', `http.${serverUrl.origin}/.extraheader`]) {
+    // always set an empyt string to clear any stored config values for the key
+    configValues.push(`${key}=`);
+
+    const options = {
+      listeners: {
+        stdout: data => {
+          // if this isn't an authorization header, keep using it
+          const headers = data.toString().match(/[^\r\n]+/g);
+          headers.map(header => header.trim())
+                 .filter(header => !header.toLowerCase().startsWith('authorization:'))
+                 .forEach(header => configValues.push(`${key}=${header}`));
+
+        }
+      }
+    };
+    await exec.exec('git', ['config', '--get-all', key], options);
+  }
+
+  return configValues.flatMap(value => ['-c', value]);
+}
+
 async function getLicensedInput() {
   const command = core.getInput('command', { required: true });
   await io.which(command.split(' ')[0], true); // check that command is runnable
@@ -133,6 +160,7 @@ async function deleteBranch(branch) {
 
 module.exports = {
   configureGit,
+  extraHeaderConfigWithoutAuthorization,
   getLicensedInput,
   getBranch,
   getCachePaths,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,11 +110,17 @@ async function filterCachePaths(paths) {
 }
 
 async function ensureBranch(branch, parent) {
+  // always fetch the work and licenses branches
+  await exec.exec('git', ['fetch', ORIGIN, branch], { ignoreReturnCode: true });
+  if (parent && branch != parent) {
+    await exec.exec('git', ['fetch', ORIGIN, parent], { ignoreReturnCode: true});
+  }
+
   // change to the target branch
-  let exitCode = await exec.exec('git', ['checkout', branch], { ignoreReturnCode: true });
-  if (exitCode != 0 && branch !== parent) {
-    await exec.exec('git', ['checkout', parent]);
-    exitCode = await exec.exec('git', ['checkout', '-b', branch], { ignoreReturnCode: true });
+  let exitCode = await exec.exec('git', ['checkout', '--track', `${ORIGIN}/${branch}`], { ignoreReturnCode: true });
+  if (exitCode != 0 && branch !== parent) {    
+    await exec.exec('git', ['checkout', '--track', `${ORIGIN}/${parent}`]);
+    exitCode = await exec.exec('git', ['checkout', '--track', '-b', `${branch}`], { ignoreReturnCode: true });
   }
 
   if (exitCode != 0) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ async function configureGit() {
 
   await exec.exec('git', ['config', 'user.name', userName]);
   await exec.exec('git', ['config', 'user.email', userEmail]);
-  await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}.git`]);
+  await exec.exec('git', ['remote', 'add', ORIGIN, `https://${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
 }
 
 async function extraHeaderConfigWithoutAuthorization() {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -31,11 +31,17 @@ async function createLicensesPullRequest(octokit, head, base, userPullRequest) {
     body
   });
 
-  await octokit.rest.pulls.requestReviewers({
-    ...github.context.repo,
-    pull_number: pull.number,
-    reviewers: [actor]
-  });
+  try {
+    // this will fail if the PR is created using a PAT 
+    // from `actor`s user account
+    await octokit.rest.pulls.requestReviewers({
+      ...github.context.repo,
+      pull_number: pull.number,
+      reviewers: [actor]
+    });
+  } catch (e) {
+    core.warning(e.message)
+  }  
 
   core.info(`Created pull request for changes: ${pull.html_url}`);
   return pull;

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -162,7 +162,7 @@ async function run() {
     await utils.ensureBranch(licensesBranch, userBranch);
 
     // ensure that branch is up to date with parent
-    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `origin/${userBranch}`], { ignoreReturnCode: true });
+    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${licensesBranch} up to date with ${userBranch}`);
     }

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -180,7 +180,9 @@ async function run() {
       // if files were changed, push them back up to origin using the passed in github token
       const commitMessage = core.getInput('commit_message', { required: true });
       await exec.exec('git', ['commit', '-m', commitMessage]);
-      await exec.exec('git', ['push', utils.getOrigin(), licensesBranch]);
+
+      const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
+      await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), licensesBranch]);
       licensesUpdated = true;
 
       const userPullRequest = await utils.findPullRequest(octokit, { head: userBranch, "-base": userBranch });

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -52,7 +52,9 @@ async function run() {
     // if files were changed, push them back up to origin using the passed in github token
     const commitMessage = core.getInput('commit_message', { required: true });
     await exec.exec('git', ['commit', '-m', commitMessage]);
-    await exec.exec('git', ['push', utils.getOrigin(), branch]);
+
+    const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
+    await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), branch]);
     licensesUpdated = true;
 
     // if a PR comment was supplied and PR exists, add comment

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -50,7 +50,7 @@ describe('configureGit', () => {
     expect(exec.exec.callCount).toEqual(3);
     expect(exec.exec.getCall(0).args).toEqual(['git', ['config', 'user.name', process.env.INPUT_USER_NAME]]);
     expect(exec.exec.getCall(1).args).toEqual(['git', ['config', 'user.email', process.env.INPUT_USER_EMAIL]]);
-    expect(exec.exec.getCall(2).args).toEqual(['git', ['remote', 'add', utils.getOrigin(), `https://x-access-token:${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}.git`]]);
+    expect(exec.exec.getCall(2).args).toEqual(['git', ['remote', 'add', utils.getOrigin(), `https://${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}`]]);
   });
 });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -294,10 +294,15 @@ describe('ensureBranch', () => {
     sinon.stub(exec, 'exec').resolves(0);
 
     await utils.ensureBranch(branch, branch);
-    expect(exec.exec.callCount).toEqual(1);
+    expect(exec.exec.callCount).toEqual(2);
     expect(exec.exec.getCall(0).args).toEqual([
       'git',
-      ['checkout', branch],
+      ['fetch', utils.getOrigin(), branch],
+      { ignoreReturnCode: true }
+    ]);
+    expect(exec.exec.getCall(1).args).toEqual([
+      'git',
+      ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
       { ignoreReturnCode: true }
     ]);
   });
@@ -305,30 +310,47 @@ describe('ensureBranch', () => {
   describe('when branch !== parent', () => {
     it('creates a branch if it doesn\'t exist', async () => {
       sinon.stub(exec, 'exec')
-        .withArgs('git', ['checkout', branch]).resolves(1)
-        .withArgs('git', ['checkout', parent]).resolves(0)
-        .withArgs('git', ['checkout', '-b', branch]).resolves(0);
+        .withArgs('git', ['fetch', utils.getOrigin(), branch]).resolves(1)
+        .withArgs('git', ['fetch', utils.getOrigin(), parent]).resolves(0)
+        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${branch}`]).resolves(1)
+        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${parent}`]).resolves(0)
+        .withArgs('git', ['checkout', '--track', '-b', branch]).resolves(0);
 
       await utils.ensureBranch(branch, parent);
-      expect(exec.exec.callCount).toEqual(3);
+      expect(exec.exec.callCount).toEqual(5);
       expect(exec.exec.getCall(0).args).toEqual([
         'git',
-        ['checkout', branch],
+        ['fetch', utils.getOrigin(), branch],
         { ignoreReturnCode: true }
       ]);
-      expect(exec.exec.getCall(1).args).toEqual(['git', ['checkout', parent]]);
+      expect(exec.exec.getCall(1).args).toEqual([
+        'git',
+        ['fetch', utils.getOrigin(), parent],
+        { ignoreReturnCode: true }
+      ]);
       expect(exec.exec.getCall(2).args).toEqual([
         'git',
-        ['checkout', '-b', branch],
+        ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
+        { ignoreReturnCode: true }
+      ]);
+      expect(exec.exec.getCall(3).args).toEqual([
+        'git',
+        ['checkout', '--track', `${utils.getOrigin()}/${parent}`]
+      ]);
+      expect(exec.exec.getCall(4).args).toEqual([
+        'git',
+        ['checkout', '--track', '-b', branch],
         { ignoreReturnCode: true }
       ]);
     });
 
     it('raises an error if checkout and create fail', async () => {
       sinon.stub(exec, 'exec')
-        .withArgs('git', ['checkout', branch]).resolves(1)
-        .withArgs('git', ['checkout', parent]).resolves(0)
-        .withArgs('git', ['checkout', '-b', branch]).resolves(1);
+        .withArgs('git', ['fetch', utils.getOrigin(), branch]).resolves(1)
+        .withArgs('git', ['fetch', utils.getOrigin(), parent]).resolves(0)
+        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${branch}`]).resolves(1)
+        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${parent}`]).resolves(0)
+        .withArgs('git', ['checkout', '-b', '--track', branch]).resolves(1);
 
       await expect(utils.ensureBranch(branch, parent)).rejects.toThrow(
         `Unable to find or create the ${branch} branch`
@@ -343,10 +365,15 @@ describe('ensureBranch', () => {
       await expect(utils.ensureBranch(branch, branch)).rejects.toThrow(
         `Unable to find or create the ${branch} branch`
       );
-      expect(exec.exec.callCount).toEqual(1);
+      expect(exec.exec.callCount).toEqual(2);
       expect(exec.exec.getCall(0).args).toEqual([
         'git',
-        ['checkout', branch],
+        ['fetch', utils.getOrigin(), branch],
+        { ignoreReturnCode: true }
+      ]);
+      expect(exec.exec.getCall(1).args).toEqual([
+        'git',
+        ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
         { ignoreReturnCode: true }
       ]);
     });

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -61,6 +61,7 @@ describe('branch workflow', () => {
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
     sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
+    sinon.stub(utils, 'extraHeaderConfigWithoutAuthorization').resolves([])
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .resolves(1)

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -65,7 +65,7 @@ describe('branch workflow', () => {
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .resolves(1)
-      .withArgs('git', ['merge', '-s', 'recursive', '-Xtheirs', `origin/${branch}`]).resolves(0)
+      .withArgs('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${branch}`]).resolves(0)
       .withArgs(command, ['cache', '-c', configFilePath]).resolves()
       .withArgs('git', ['add', '--', ...cachePaths]).resolves()
       .withArgs('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths]).resolves(0);
@@ -108,7 +108,7 @@ describe('branch workflow', () => {
     expect(exec.exec.callCount).toEqual(5);
     expect(exec.exec.getCall(0).args).toEqual([
       'git',
-      ['merge', '-s', 'recursive', '-Xtheirs', `origin/${branch}`],
+      ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${branch}`],
       { ignoreReturnCode: true }
     ]);
     expect(exec.exec.getCall(1).args).toEqual([command, ['cache', '-c', configFilePath]]);

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -50,6 +50,7 @@ describe('push workflow', () => {
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
     sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
+    sinon.stub(utils, 'extraHeaderConfigWithoutAuthorization').resolves([])
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .rejects()


### PR DESCRIPTION
This PR updates a few issues I've seen using the action.

1. License metadata pushes aren't actually being done as the `github_token` input value 😨 .  This is due to the actions/checkout action setting `http.{server}.extraheader=AUTHORIZATION basic <token used for checkout>` in the git config by default.  That behavior can be turned off by setting `persist-credentials: false` on the action, but this action relies on that value never being set and should account for it no matter how actions/checkout is configured.
   - Fixed this by using `git -c` configuration flags to override previous extraheader values for both the global `http.extraheader` and the more specific `http.{server url}.extraheader` that is set by actions/checkout.  `server url` for most cases will be `https://github.com/` but could be set from a [GITHUB_SERVER_URL](https://github.com/actions/checkout/blob/230611dbd0eb52da1e1f4f7bc8bb0c3a339fc8b7/src/url-helper.ts#L25) environment variable in GHES.  Overriding this only on the push command seemed the lease obtrusive way to manage this.
   - The fix will persist any non-authorization extraheader values to not mess up git configurations that exist for other reasons.

1. Makes the action more resilient to various options set when using actions/checkout@v2+.  The v2 release by default will only fetch the single commit that caused the action to run, where this action needs full branches to be checked out.  Users can set `fetch-depth` on actions/checkout to make this work, but it's honestly easier to just ensure that the branches needed by the action are fully fetched and usable in all cases 🤷 

1. An error was thrown when (1) the branch workflow is used, and (2) the token that this action is executed with belongs to the actor that caused the action execution.  The error occurred because the token would cause the PR to be opened as the actor, and the action would try to set the actor as a reviewer on the new PR.  This combination raised an error because authors cannot be assigned as reviewers on their own PRs.  I can't easily check the token's owner without an API call which adds more runtime and API usage so instead I'm just catching the error and logging it as a warning.