### PR TITLE
remove explicit acorn reference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
       },
       "devDependencies": {
         "@vercel/ncc": "^0.31",
-        "acorn": "^8.5",
         "eslint": "^8.2.0",
         "husky": "^7.0.4",
         "jest": "^27.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.31",
-    "acorn": "^8.5",
     "eslint": "^8.2.0",
     "husky": "^7.0.4",
     "jest": "^27.3",


### PR DESCRIPTION
This is a nested dependency that I think ended up as an explicit ref to force a version bump.  It's not needed any more