### PR TITLE
Don't fail git config call when no config values are set

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,6 +61,7 @@ async function extraHeaderConfigWithoutAuthorization() {
     configValues.push(`${key}=`);
 
     const options = {
+      ignoreReturnCode: true,
       listeners: {
         stdout: data => {
           // if this isn't an authorization header, keep using it

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,6 +27,7 @@ async function extraHeaderConfigWithoutAuthorization() {
     configValues.push(`${key}=`);
 
     const options = {
+      ignoreReturnCode: true,
       listeners: {
         stdout: data => {
           // if this isn't an authorization header, keep using it


### PR DESCRIPTION
🤦  found this after some quick testing in a prod environment.  The `git config` call will return with an error exit code if there are no values set.  This is not an error case for the usage here and shouldn't be cause an error to be raised