### PR TITLE
Reinstate x-access-token in remote url

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -48,7 +48,7 @@ async function configureGit() {
 
   await exec.exec('git', ['config', 'user.name', userName]);
   await exec.exec('git', ['config', 'user.email', userEmail]);
-  await exec.exec('git', ['remote', 'add', ORIGIN, `https://${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
+  await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
 }
 
 async function extraHeaderConfigWithoutAuthorization() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ async function configureGit() {
 
   await exec.exec('git', ['config', 'user.name', userName]);
   await exec.exec('git', ['config', 'user.email', userEmail]);
-  await exec.exec('git', ['remote', 'add', ORIGIN, `https://${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
+  await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
 }
 
 async function extraHeaderConfigWithoutAuthorization() {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -50,7 +50,7 @@ describe('configureGit', () => {
     expect(exec.exec.callCount).toEqual(3);
     expect(exec.exec.getCall(0).args).toEqual(['git', ['config', 'user.name', process.env.INPUT_USER_NAME]]);
     expect(exec.exec.getCall(1).args).toEqual(['git', ['config', 'user.email', process.env.INPUT_USER_EMAIL]]);
-    expect(exec.exec.getCall(2).args).toEqual(['git', ['remote', 'add', utils.getOrigin(), `https://${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}`]]);
+    expect(exec.exec.getCall(2).args).toEqual(['git', ['remote', 'add', utils.getOrigin(), `https://x-access-token:${process.env.INPUT_GITHUB_TOKEN}@github.com/${process.env.GITHUB_REPOSITORY}`]]);
   });
 });
 


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/96

Looks like `x-access-token` is needed in the remote url after all 😞 , I'm guessing for situations where the token isn't a PAT.  

This PR reverts that particular change from https://github.com/jonabc/licensed-ci/pull/92

cc @nadavshatz