### PR TITLE
Use unique, unshallow branches for licensed remote

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -111,22 +111,31 @@ async function filterCachePaths(paths) {
 }
 
 async function ensureBranch(branch, parent) {
+  const localBranch = `${ORIGIN}/${branch}`;
+  const localParent = `${ORIGIN}/${parent}`;
+
   // always fetch the work and licenses branches
-  await exec.exec('git', ['fetch', ORIGIN, branch], { ignoreReturnCode: true });
+  const fetchOpts = [];
+  if (fs.existsSync('.git/shallow')) {
+    fetchOpts.push('--unshallow');
+  }
+
+  let exitCode = await exec.exec('git', ['fetch', ...fetchOpts, ORIGIN, branch], { ignoreReturnCode: true });
   if (parent && branch != parent) {
     await exec.exec('git', ['fetch', ORIGIN, parent], { ignoreReturnCode: true});
   }
 
   // change to the target branch
-  let exitCode = await exec.exec('git', ['checkout', '--track', `${ORIGIN}/${branch}`], { ignoreReturnCode: true });
+  exitCode = await exec.exec('git', ['checkout', '--force', '-B', localBranch, `refs/remotes/${ORIGIN}/${branch}`], { ignoreReturnCode: true });
   if (exitCode != 0 && branch !== parent) {    
-    await exec.exec('git', ['checkout', '--track', `${ORIGIN}/${parent}`]);
-    exitCode = await exec.exec('git', ['checkout', '--track', '-b', `${branch}`], { ignoreReturnCode: true });
+    exitCode = await exec.exec('git', ['checkout', '--force', '-B', localBranch, `refs/remotes/${ORIGIN}/${parent}`], { ignoreReturnCode: true });
   }
 
   if (exitCode != 0) {
     throw new Error(`Unable to find or create the ${branch} branch`);
   }
+
+  return [localBranch, localParent];
 }
 
 async function findPullRequest(octokit, options={}) {

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -165,10 +165,10 @@ async function run() {
   // recache data only when on a non-licenses branch
   if (branch !== licensesBranch) {
     // change to a `<branch>-licenses` branch to continue updates
-    await utils.ensureBranch(licensesBranch, userBranch);
+    const [localLicensesBranch, localUserBranch] = await utils.ensureBranch(licensesBranch, userBranch);
 
     // ensure that branch is up to date with parent
-    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
+    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', localUserBranch], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${licensesBranch} up to date with ${userBranch}`);
     }
@@ -188,7 +188,7 @@ async function run() {
       await exec.exec('git', ['commit', '-m', commitMessage]);
 
       const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
-      await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), licensesBranch]);
+      await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), `${localLicensesBranch}:${licensesBranch}`]);
       licensesUpdated = true;
 
       const userPullRequest = await utils.findPullRequest(octokit, { head: userBranch, "-base": userBranch });

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -32,7 +32,7 @@ async function run() {
     return;
   }
 
-  await utils.ensureBranch(branch, branch);
+  const [localBranch] = await utils.ensureBranch(branch, branch);
 
   // find an open pull request for the changes if one exists
   const token = core.getInput('github_token', { required: true });
@@ -54,7 +54,7 @@ async function run() {
     await exec.exec('git', ['commit', '-m', commitMessage]);
 
     const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
-    await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), branch]);
+    await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), `${localBranch}:${branch}`]);
     licensesUpdated = true;
 
     // if a PR comment was supplied and PR exists, add comment

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -286,6 +286,10 @@ describe('ensureBranch', () => {
   let branch = 'branch';
   let parent = 'parent';
 
+  beforeEach(() => {
+    sinon.stub(fs, 'existsSync').withArgs('.git/shallow').returns(false);
+  });
+
   afterEach(() => {
     sinon.restore();
   });
@@ -303,6 +307,19 @@ describe('ensureBranch', () => {
     expect(exec.exec.getCall(1).args).toEqual([
       'git',
       ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`],
+      { ignoreReturnCode: true }
+    ]);
+  });
+
+  it('checks out a branch with unshallow if .git/shallow file exists', async () => {
+    fs.existsSync.withArgs('.git/shallow').returns(true);
+    sinon.stub(exec, 'exec').resolves(0);
+
+    await utils.ensureBranch(branch, branch);
+    expect(exec.exec.callCount).toEqual(2);
+    expect(exec.exec.getCall(0).args).toEqual([
+      'git',
+      ['fetch', '--unshallow', utils.getOrigin(), branch],
       { ignoreReturnCode: true }
     ]);
   });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -302,7 +302,7 @@ describe('ensureBranch', () => {
     ]);
     expect(exec.exec.getCall(1).args).toEqual([
       'git',
-      ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
+      ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`],
       { ignoreReturnCode: true }
     ]);
   });
@@ -312,12 +312,11 @@ describe('ensureBranch', () => {
       sinon.stub(exec, 'exec')
         .withArgs('git', ['fetch', utils.getOrigin(), branch]).resolves(1)
         .withArgs('git', ['fetch', utils.getOrigin(), parent]).resolves(0)
-        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${branch}`]).resolves(1)
-        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${parent}`]).resolves(0)
-        .withArgs('git', ['checkout', '--track', '-b', branch]).resolves(0);
+        .withArgs('git', ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`]).resolves(1)
+        .withArgs('git', ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${parent}`]).resolves(0);
 
       await utils.ensureBranch(branch, parent);
-      expect(exec.exec.callCount).toEqual(5);
+      expect(exec.exec.callCount).toEqual(4);
       expect(exec.exec.getCall(0).args).toEqual([
         'git',
         ['fetch', utils.getOrigin(), branch],
@@ -330,16 +329,12 @@ describe('ensureBranch', () => {
       ]);
       expect(exec.exec.getCall(2).args).toEqual([
         'git',
-        ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
+        ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`],
         { ignoreReturnCode: true }
       ]);
       expect(exec.exec.getCall(3).args).toEqual([
         'git',
-        ['checkout', '--track', `${utils.getOrigin()}/${parent}`]
-      ]);
-      expect(exec.exec.getCall(4).args).toEqual([
-        'git',
-        ['checkout', '--track', '-b', branch],
+        ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${parent}`],
         { ignoreReturnCode: true }
       ]);
     });
@@ -348,9 +343,8 @@ describe('ensureBranch', () => {
       sinon.stub(exec, 'exec')
         .withArgs('git', ['fetch', utils.getOrigin(), branch]).resolves(1)
         .withArgs('git', ['fetch', utils.getOrigin(), parent]).resolves(0)
-        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${branch}`]).resolves(1)
-        .withArgs('git', ['checkout', '--track', `${utils.getOrigin()}/${parent}`]).resolves(0)
-        .withArgs('git', ['checkout', '-b', '--track', branch]).resolves(1);
+        .withArgs('git', ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`]).resolves(1)
+        .withArgs('git', ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${parent}`]).resolves(1);
 
       await expect(utils.ensureBranch(branch, parent)).rejects.toThrow(
         `Unable to find or create the ${branch} branch`
@@ -373,7 +367,7 @@ describe('ensureBranch', () => {
       ]);
       expect(exec.exec.getCall(1).args).toEqual([
         'git',
-        ['checkout', '--track', `${utils.getOrigin()}/${branch}`],
+        ['checkout', '--force', '-B', `${utils.getOrigin()}/${branch}`, `refs/remotes/${utils.getOrigin()}/${branch}`],
         { ignoreReturnCode: true }
       ]);
     });

--- a/test/workflows/branch.test.js
+++ b/test/workflows/branch.test.js
@@ -17,6 +17,8 @@ describe('branch workflow', () => {
 
   const branch = 'branch';
   const licensesBranch = 'branch-licenses';
+  const localBranch = `${utils.getOrigin()}/${branch}`;
+  const localLicensesBranch = `${utils.getOrigin()}/${licensesBranch}`;
 
   const pullRequest = require(path.normalize(path.join(__dirname, '..', 'fixtures', 'pullRequest.json')));
 
@@ -57,7 +59,7 @@ describe('branch workflow', () => {
 
     sinon.stub(utils, 'getBranch').returns(branch);
     sinon.stub(utils, 'getLicensedInput').resolves({ command, configFilePath });
-    sinon.stub(utils, 'ensureBranch').resolves();
+    sinon.stub(utils, 'ensureBranch').resolves([localLicensesBranch, localBranch]);
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
     sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
@@ -65,7 +67,7 @@ describe('branch workflow', () => {
     sinon.stub(github, 'getOctokit').returns(octokit);
     sinon.stub(exec, 'exec')
       .resolves(1)
-      .withArgs('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${branch}`]).resolves(0)
+      .withArgs('git', ['merge', '-s', 'recursive', '-Xtheirs', localBranch]).resolves(0)
       .withArgs(command, ['cache', '-c', configFilePath]).resolves()
       .withArgs('git', ['add', '--', ...cachePaths]).resolves()
       .withArgs('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths]).resolves(0);
@@ -108,7 +110,7 @@ describe('branch workflow', () => {
     expect(exec.exec.callCount).toEqual(5);
     expect(exec.exec.getCall(0).args).toEqual([
       'git',
-      ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${branch}`],
+      ['merge', '-s', 'recursive', '-Xtheirs', localBranch],
       { ignoreReturnCode: true }
     ]);
     expect(exec.exec.getCall(1).args).toEqual([command, ['cache', '-c', configFilePath]]);
@@ -208,7 +210,7 @@ describe('branch workflow', () => {
   describe('with no cached file changes', () => {
     it('does not push changes to origin', async () => {
       await expect(workflow()).rejects.toThrow();
-      expect(exec.exec.neverCalledWith('git', ['push', utils.getOrigin(), branch])).toEqual(true);
+      expect(exec.exec.neverCalledWith('git', ['push', utils.getOrigin(), `${localLicensesBranch}:${licensesBranch}`])).toEqual(true);
       expect(core.setOutput.calledWith('licenses_updated', 'false')).toEqual(true);
     });
   });
@@ -225,7 +227,7 @@ describe('branch workflow', () => {
       exec.exec
         .withArgs('git', ['diff-index', '--quiet', 'HEAD', '--', ...cachePaths]).resolves(1)
         .withArgs('git', ['commit', '-m', commitMessage]).resolves()
-        .withArgs('git', ['push', utils.getOrigin(), licensesBranch]).resolves();
+        .withArgs('git', ['push', utils.getOrigin(), `${localLicensesBranch}:${licensesBranch}`]).resolves();
 
       utils.findPullRequest
         .withArgs(octokit, { head: licensesBranch, base: branch }).resolves(licensesPullRequest)
@@ -235,7 +237,7 @@ describe('branch workflow', () => {
     it('pushes changes to origin', async () => {
       await expect(workflow()).rejects.toThrow();
       expect(exec.exec.calledWith('git', ['commit', '-m', commitMessage])).toEqual(true);
-      expect(exec.exec.calledWith('git', ['push', utils.getOrigin(), licensesBranch])).toEqual(true);
+      expect(exec.exec.calledWith('git', ['push', utils.getOrigin(), `${localLicensesBranch}:${licensesBranch}`])).toEqual(true);
       expect(core.setOutput.calledWith('licenses_updated', 'true')).toEqual(true);
     });
 

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -16,6 +16,7 @@ describe('push workflow', () => {
   const cachePaths = ['cache1', 'cache2'];
 
   const branch = 'branch';
+  const localBranch = `${utils.getOrigin()}/${branch}`;
 
   // to match the response from the testSearchResult.json fixture
   const owner = 'jonabc';
@@ -46,7 +47,7 @@ describe('push workflow', () => {
 
     sinon.stub(utils, 'getBranch').returns('branch');
     sinon.stub(utils, 'getLicensedInput').resolves({ command, configFilePath });
-    sinon.stub(utils, 'ensureBranch').resolves();
+    sinon.stub(utils, 'ensureBranch').resolves([localBranch, localBranch]);
     sinon.stub(utils, 'findPullRequest').resolves(null);
     sinon.stub(utils, 'getCachePaths').resolves(cachePaths);
     sinon.stub(utils, 'filterCachePaths').resolves(cachePaths);
@@ -142,7 +143,7 @@ describe('push workflow', () => {
   describe('with no cached file changes', () => {
     it('does not push changes to origin', async () => {
       await workflow();
-      expect(exec.exec.neverCalledWith('git', ['push', utils.getOrigin(), branch])).toEqual(true);
+      expect(exec.exec.neverCalledWith('git', ['push', utils.getOrigin(), `${localBranch}:${branch}`])).toEqual(true);
       expect(core.setOutput.calledWith('licenses_updated', 'false')).toEqual(true);
     });
   });
@@ -171,7 +172,7 @@ describe('push workflow', () => {
     it('pushes changes to origin', async () => {
       await workflow();
       expect(exec.exec.calledWith('git', ['commit', '-m', commitMessage])).toEqual(true);
-      expect(exec.exec.calledWith('git', ['push', utils.getOrigin(), branch])).toEqual(true);
+      expect(exec.exec.calledWith('git', ['push', utils.getOrigin(), `${localBranch}:${branch}`])).toEqual(true);
       expect(core.setOutput.calledWith('licenses_updated', 'true')).toEqual(true);
     });
 


### PR DESCRIPTION
Fixes a current issue with using the action with `push` action events, the `branch` workflow strategy, and a shallow checkout from `actions/checkout`.

One of the underlying principles of this action is that it should "just work" without thrashing the local actions environment.  I tried to accomplish that by using a separate remote and only affecting branches from that remote.  I thought that would be enough to avoid interactions with shallow fetches done by default with `actions/checkout@v2`, but that was wrong. 
 The error scenario comes together as a perfect storm combination of:
- the push action event, where the commit SHA is the ref head and is used by default in `actions/checkout`
   - the shallow fetch here puts the commit SHA into the `.git/shallow` tracking file
- the branch licensed-ci workflow, which creates a separate branch to track license metadata updates
   - in order to merge any updates from the users branch into the license metadata update branch, the branches need a common ancestor for a merge base

When the shallow fetch is done using the commit SHA, creating a new unique branch where the commit SHA is `HEAD`  still results in a shallow fetch of the new branch.  In the branch worfklow, the impact of this is that the current branch under test is always going to be shallow.

This change enforces `--unshallow` on a fetch call and returns the local branch names that should be used in further git operations to callers.

