### PR TITLE
Set git user config per call

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -42,12 +42,7 @@ const stream = __nccwpck_require__(2781);
 const ORIGIN = 'licensed-ci-origin';
 
 async function configureGit() {
-  const userName = core.getInput('user_name', { required: true });
-  const userEmail = core.getInput('user_email', { required: true });
   const token = core.getInput('github_token', { required: true });
-
-  await exec.exec('git', ['config', 'user.name', userName]);
-  await exec.exec('git', ['config', 'user.email', userEmail]);
   await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
 }
 
@@ -77,6 +72,16 @@ async function extraHeaderConfigWithoutAuthorization() {
   }
 
   return configValues.flatMap(value => ['-c', value]);
+}
+
+function userConfig() {
+  const userName = core.getInput('user_name', { required: true });
+  const userEmail = core.getInput('user_email', { required: true });
+
+  return [
+    '-c', `user.name=${userName}`,
+    '-c', `user.email=${userEmail}`
+  ]
 }
 
 async function getLicensedInput() {
@@ -202,6 +207,7 @@ async function deleteBranch(branch) {
 module.exports = {
   configureGit,
   extraHeaderConfigWithoutAuthorization,
+  userConfig,
   getLicensedInput,
   getBranch,
   getCachePaths,
@@ -390,7 +396,7 @@ async function run() {
     await utils.ensureBranch(licensesBranch, userBranch);
 
     // ensure that branch is up to date with parent
-    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
+    let exitCode = await exec.exec('git', [...utils.userConfig(), 'merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${licensesBranch} up to date with ${userBranch}`);
     }
@@ -407,7 +413,7 @@ async function run() {
     if (exitCode > 0) {
       // if files were changed, push them back up to origin using the passed in github token
       const commitMessage = core.getInput('commit_message', { required: true });
-      await exec.exec('git', ['commit', '-m', commitMessage]);
+      await exec.exec('git', [...utils.userConfig(), 'commit', '-m', commitMessage]);
 
       const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
       await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), licensesBranch]);
@@ -513,7 +519,8 @@ async function run() {
   if (exitCode > 0) {
     // if files were changed, push them back up to origin using the passed in github token
     const commitMessage = core.getInput('commit_message', { required: true });
-    await exec.exec('git', ['commit', '-m', commitMessage]);
+    const userConfig = utils.userConfig();
+    await exec.exec('git', [...userConfig, 'commit', '-m', commitMessage]);
 
     const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
     await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), branch]);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,12 +8,7 @@ const stream = require('stream');
 const ORIGIN = 'licensed-ci-origin';
 
 async function configureGit() {
-  const userName = core.getInput('user_name', { required: true });
-  const userEmail = core.getInput('user_email', { required: true });
   const token = core.getInput('github_token', { required: true });
-
-  await exec.exec('git', ['config', 'user.name', userName]);
-  await exec.exec('git', ['config', 'user.email', userEmail]);
   await exec.exec('git', ['remote', 'add', ORIGIN, `https://x-access-token:${token}@github.com/${process.env.GITHUB_REPOSITORY}`]);
 }
 
@@ -43,6 +38,16 @@ async function extraHeaderConfigWithoutAuthorization() {
   }
 
   return configValues.flatMap(value => ['-c', value]);
+}
+
+function userConfig() {
+  const userName = core.getInput('user_name', { required: true });
+  const userEmail = core.getInput('user_email', { required: true });
+
+  return [
+    '-c', `user.name=${userName}`,
+    '-c', `user.email=${userEmail}`
+  ]
 }
 
 async function getLicensedInput() {
@@ -168,6 +173,7 @@ async function deleteBranch(branch) {
 module.exports = {
   configureGit,
   extraHeaderConfigWithoutAuthorization,
+  userConfig,
   getLicensedInput,
   getBranch,
   getCachePaths,

--- a/lib/workflows/branch.js
+++ b/lib/workflows/branch.js
@@ -168,7 +168,7 @@ async function run() {
     await utils.ensureBranch(licensesBranch, userBranch);
 
     // ensure that branch is up to date with parent
-    let exitCode = await exec.exec('git', ['merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
+    let exitCode = await exec.exec('git', [...utils.userConfig(), 'merge', '-s', 'recursive', '-Xtheirs', `${utils.getOrigin()}/${userBranch}`], { ignoreReturnCode: true });
     if (exitCode !== 0) {
       throw new Error(`Unable to get ${licensesBranch} up to date with ${userBranch}`);
     }
@@ -185,7 +185,7 @@ async function run() {
     if (exitCode > 0) {
       // if files were changed, push them back up to origin using the passed in github token
       const commitMessage = core.getInput('commit_message', { required: true });
-      await exec.exec('git', ['commit', '-m', commitMessage]);
+      await exec.exec('git', [...utils.userConfig(), 'commit', '-m', commitMessage]);
 
       const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
       await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), licensesBranch]);

--- a/lib/workflows/push.js
+++ b/lib/workflows/push.js
@@ -51,7 +51,8 @@ async function run() {
   if (exitCode > 0) {
     // if files were changed, push them back up to origin using the passed in github token
     const commitMessage = core.getInput('commit_message', { required: true });
-    await exec.exec('git', ['commit', '-m', commitMessage]);
+    const userConfig = utils.userConfig();
+    await exec.exec('git', [...userConfig, 'commit', '-m', commitMessage]);
 
     const extraHeadersConfig = await utils.extraHeaderConfigWithoutAuthorization();
     await exec.exec('git', [...extraHeadersConfig, 'push', utils.getOrigin(), branch]);

--- a/test/workflows/push.test.js
+++ b/test/workflows/push.test.js
@@ -20,6 +20,7 @@ describe('push workflow', () => {
   // to match the response from the testSearchResult.json fixture
   const owner = 'jonabc';
   const repo = 'setup-licensed';
+  const userConfig = ['-c', 'config=value'];
 
   let octokit;
   let createCommentEndpoint;
@@ -44,6 +45,7 @@ describe('push workflow', () => {
     sinon.stub(core, 'warning');
     sinon.stub(core, 'setOutput');
 
+    sinon.stub(utils, 'userConfig').returns(userConfig);
     sinon.stub(utils, 'getBranch').returns('branch');
     sinon.stub(utils, 'getLicensedInput').resolves({ command, configFilePath });
     sinon.stub(utils, 'ensureBranch').resolves();
@@ -170,7 +172,7 @@ describe('push workflow', () => {
 
     it('pushes changes to origin', async () => {
       await workflow();
-      expect(exec.exec.calledWith('git', ['commit', '-m', commitMessage])).toEqual(true);
+      expect(exec.exec.calledWith('git', [...userConfig, 'commit', '-m', commitMessage])).toEqual(true);
       expect(exec.exec.calledWith('git', ['push', utils.getOrigin(), branch])).toEqual(true);
       expect(core.setOutput.calledWith('licenses_updated', 'true')).toEqual(true);
     });


### PR DESCRIPTION
This is a non-necessary fix but is a move towards the general strategy that this action should not leave lasting changes in the local git environment.  Rather than overwriting the local git config to set a user name and email this change sets the configured user name and email on individual git calls that require it with `-c user.name=... -c user.email=...`