### PR TITLE
Enable schedule events by picking up branch name from more sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Notes:
 
 ### Supported Events
 
-This action supports the `push`, `pull_request` and `workflow_dispatch` events.  When using `push`, the action workflow should include `tags-ignore: '**'` to avoid running the action on pushed tags.  New tags point to code but do not represent new or changed code that could include updated dependencies.
+This action supports the `push`, `pull_request`, `workflow_dispatch`, and `scheduled` events.  When using `push`, the action workflow should include `tags-ignore: '**'` to avoid running the action on pushed tags.  New tags point to code but do not represent new or changed code that could include updated dependencies.
 
 ```yaml
 on:
@@ -77,6 +77,9 @@ on:
       - synchronize
   # run on demand
   workflow_dispatch:
+  # run on a schedule against the repository's default branch
+  schedule:
+    - cron: '0 8 * * *' # run every day at 8am
 ```
 
 ### Basic Ruby usage using Bundler + Gemfile

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,9 @@ inputs:
     description: 'Whether to close open PRs and delete license branches on CI success in user branch. Only used by `branch` workflow'
     required: false
     default: 'false'
+  branch:
+    description: 'Branch to run the action on when using `workflow_dispatch` or `schedule` event triggers'
+    required: false
 outputs:
   licenses_branch:
     description: The branch containing licensed-ci changes.

--- a/dist/index.js
+++ b/dist/index.js
@@ -452,7 +452,7 @@ async function run() {
       }
     }
 
-    await exec.exec('git', ['checkout', '--track', localUserBranch]);
+    await exec.exec('git', ['checkout', branch]);
   }
 
   core.setOutput('licenses_updated', licensesUpdated.toString());

--- a/dist/index.js
+++ b/dist/index.js
@@ -109,6 +109,12 @@ async function checkStatus(command, configFilePath) {
 }
 
 function getBranch(context) {
+  // allow the user to specify a branch to run the action on
+  const branch = core.getInput('branch', { required: false });
+  if (branch) {
+    return branch;
+  }
+
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref;
   } else if (context.payload && context.payload.ref) {
@@ -117,6 +123,8 @@ function getBranch(context) {
       throw new Error(`${ref} does not reference a branch`);
     }
     return ref.replace('refs/heads/', '');
+  } else if (context.ref && context.ref.startsWith('refs/heads')) {
+    return context.ref.replace('refs/heads/', '');
   }
 
   throw new Error(`Unable to determine a HEAD branch reference for ${context.eventName} event type`);
@@ -444,7 +452,7 @@ async function run() {
       }
     }
 
-    await exec.exec('git', ['checkout', branch]);
+    await exec.exec('git', ['checkout', '--track', localUserBranch]);
   }
 
   core.setOutput('licenses_updated', licensesUpdated.toString());

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,6 +75,12 @@ async function checkStatus(command, configFilePath) {
 }
 
 function getBranch(context) {
+  // allow the user to specify a branch to run the action on
+  const branch = core.getInput('branch', { required: false });
+  if (branch) {
+    return branch;
+  }
+
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref;
   } else if (context.payload && context.payload.ref) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -83,6 +83,8 @@ function getBranch(context) {
       throw new Error(`${ref} does not reference a branch`);
     }
     return ref.replace('refs/heads/', '');
+  } else if (context.ref && context.ref.startsWith('refs/heads')) {
+    return context.ref.replace('refs/heads/', '');
   }
 
   throw new Error(`Unable to determine a HEAD branch reference for ${context.eventName} event type`);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -207,6 +207,10 @@ describe('checkStatus', () => {
 });
 
 describe('getBranch', () => {
+  afterEach(() => {
+    process.env = processEnv;
+  });
+
   it('raises an error when ref is not found', () => {
     expect(() => utils.getBranch({})).toThrow(
       'Unable to determine a HEAD branch reference for undefined event type'
@@ -238,6 +242,11 @@ describe('getBranch', () => {
     expect(() => utils.getBranch({ ref: 'refs/pulls/123/merge' })).toThrow(
       'Unable to determine a HEAD branch reference for undefined event type'
     );
+  });
+
+  it('returns a user-provided input value', () => {
+    process.env.INPUT_BRANCH = 'branch';
+    expect(utils.getBranch({})).toEqual('branch');
   });
 });
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -231,6 +231,14 @@ describe('getBranch', () => {
 
     expect(utils.getBranch(context)).toEqual('branch');
   });
+
+  it('returns a head branch name from context.ref if not otherwise available', () => {
+    expect(utils.getBranch({ ref: 'refs/heads/branch' })).toEqual('branch');
+
+    expect(() => utils.getBranch({ ref: 'refs/pulls/123/merge' })).toThrow(
+      'Unable to determine a HEAD branch reference for undefined event type'
+    );
+  });
 });
 
 describe('getCachePaths', () => {


### PR DESCRIPTION
closes https://github.com/jonabc/licensed-ci/issues/133

This change adds in picking up the user's working branch from a few more contexts:
1. From `context.ref`, if the branch name isn't picked up from existing sources and if the ref matches the `refs/heads/*` pattern
1. From user-provided input.  If the user input is set, that value will override other potential inputs and will always be used.

cc @villelahdenvuo 