### PR TITLE
Update CI workflows and readme for running licensed v4

### DIFF
--- a/.github/workflows/licensed-ci.yml
+++ b/.github/workflows/licensed-ci.yml
@@ -24,12 +24,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    
+    # setup node environment and packages
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
 
     - run: npm install --production --ignore-scripts
 
+    # install licensed
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
     - uses: jonabc/setup-licensed@v1
       with:
-        version: '3.x'
+        version: '4.x'
 
     - uses: ./
       with:

--- a/.github/workflows/test-licenses.yml
+++ b/.github/workflows/test-licenses.yml
@@ -16,9 +16,15 @@ jobs:
         node-version: ${{ matrix.node }}
 
     - run: npm install --production --ignore-scripts
+
+    # install licensed
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
     - uses: jonabc/setup-licensed@v1
       with:
-        version: '3.x'
+        version: '4.x'
+
     - uses: ./
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,13 @@ jobs:
         node-version: ${{ matrix.node }}
 
     - run: npm install
+
+    # install licensed
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ruby
     - uses: jonabc/setup-licensed@v1
       with:
-        version: '3.x'
+        version: '4.x'
+
     - run: npm run test

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 3.1
           bundler-cache: true # improve performance on subsequent runs
           cache-version: 1
       - run: xxx # Install project dependencies here.
@@ -124,9 +124,17 @@ jobs:
   licensed:
     steps:
       - uses: actions/checkout@v3
+      
+      # install licensed.  licensed v4 can only be installed as a gem and requires
+      # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
+      # require a specific version of ruby, default to installing latest stable
+      - uses: ruby/setup-ruby
+        with:
+          ruby-version: ruby
       - uses: jonabc/setup-licensed@v1
         with:
-          version: 3.x
+          version: 4.x
+
       - run: xxx # Install project dependencies here.
       - uses: jonabc/licensed-ci@v1
         with:
@@ -200,15 +208,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      # install environment pre-requisites and project dependencies
       - uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: npm # cache dependencies for faster subsequent runs.
-      # install your projects dependencies
       - run: npm install --production --ignore-scripts
+
+      # install licensed.  licensed v4 can only be installed as a gem and requires
+      # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
+      # require a specific version of ruby, default to installing latest stable
+      - uses: ruby/setup-ruby
+        with:
+          ruby-version: ruby
       - uses: jonabc/setup-licensed@v1
         with:
-          version: 3.x
+          version: 4.x
+
       - id: licensed
         uses: jonabc/licensed-ci@v1
         with:


### PR DESCRIPTION
This updates the references and usage of licensed v3 to licensed v4 in the repo.  The biggest change in the v4 release was that licensed no longer build and releases executables and requires installing licensed as a gem.  [jonabc/setup-licensed](https://github.com/jonabc/setup-licensed) has always preferred to install licensed as a ruby gem when possible, so the only updates needed to support v4 should be running the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) action so that a user-modifiable ruby gems install location is available.

This PR also resolves https://github.com/jonabc/licensed-ci/issues/178.  After dropping support for the release executables, licensed is no longer tied to ruby 2.6 which was bundled into the executables.  I've set the installed ruby version to `ruby` to always use the latest release because that generally fits my preferred workflow but other's may find it better to tie to a specific major, minor or patch release version.