### PR TITLE
update workflow examples to include action ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ jobs:
       # install licensed.  licensed v4 can only be installed as a gem and requires
       # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
       # require a specific version of ruby, default to installing latest stable
-      - uses: ruby/setup-ruby
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
       - uses: jonabc/setup-licensed@v1
@@ -219,7 +219,7 @@ jobs:
       # install licensed.  licensed v4 can only be installed as a gem and requires
       # running ruby/setup-ruby before jonabc/setup-licensed.  If a project doesn't
       # require a specific version of ruby, default to installing latest stable
-      - uses: ruby/setup-ruby
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
       - uses: jonabc/setup-licensed@v1


### PR DESCRIPTION
This small pull request fixes an error: "_the `uses' attribute must be a path, a Docker image, or owner/repo@ref_" when copying over the full example to test the workflow.