### PR TITLE
Handle `merge_group` payloads

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -222,6 +222,8 @@ function getBranch(context) {
 
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref;
+  } else if (context.payload && context.payload.merge_group) {
+    return context.payload.merge_group.head_ref;
   } else if (context.payload && context.payload.ref) {
     const ref = context.payload.ref;
     if (!ref.startsWith('refs/heads')) {
@@ -6289,7 +6291,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 
 var BottleneckLight = _interopDefault(__nccwpck_require__(1174));
 
-const VERSION = "4.3.2";
+const VERSION = "5.0.1";
 
 const noop = () => Promise.resolve();
 // @ts-expect-error
@@ -6431,7 +6433,7 @@ function throttling(octokit, octokitOptions) {
   if (typeof (isUsingDeprecatedOnAbuseLimitHandler ? state.onAbuseLimit : state.onSecondaryRateLimit) !== "function" || typeof state.onRateLimit !== "function") {
     throw new Error(`octokit/plugin-throttling error:
         You must pass the onSecondaryRateLimit and onRateLimit error handlers.
-        See https://github.com/octokit/rest.js#throttling
+        See https://octokit.github.io/rest.js/#throttling
 
         const octokit = new Octokit({
           throttle: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,6 +143,8 @@ function getBranch(context) {
 
   if (context.payload && context.payload.pull_request) {
     return context.payload.pull_request.head.ref;
+  } else if (context.payload && context.payload.merge_group) {
+    return context.payload.merge_group.head_ref;
   } else if (context.payload && context.payload.ref) {
     const ref = context.payload.ref;
     if (!ref.startsWith('refs/heads')) {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -302,6 +302,12 @@ describe('getBranch', () => {
     expect(utils.getBranch(context)).toEqual('branch');
   });
 
+  it('returns a head ref from a merge group payload', () => {
+    const context = { payload: { ref: 'refs/heads/branch', merge_group: { head_ref: 'branch' }}};
+    
+    expect(utils.getBranch(context)).toEqual('branch');
+  });
+
   it('returns a head branch name from context.ref if not otherwise available', () => {
     expect(utils.getBranch({ ref: 'refs/heads/branch' })).toEqual('branch');
 


### PR DESCRIPTION
This PR adds support for handling [`merge_group` event types from GitHub Actions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#merge_group).  The [merge_group webook payload](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#merge_group) includes a `merge_group` object with a `head_ref` field that's used here.